### PR TITLE
Set errorTriggered=false at the beginning of each loop in deleteTweets

### DIFF
--- a/src/renderer/src/view_models/AccountXViewModel.ts
+++ b/src/renderer/src/view_models/AccountXViewModel.ts
@@ -1540,8 +1540,9 @@ Hang on while I scroll down to your earliest likes.`;
         this.progress.newTweetsArchived = 0;
         await this.syncProgress();
 
-        let errorTriggered = false;
+        let errorTriggered;
         for (let i = 0; i < tweetsToDelete.tweets.length; i++) {
+            errorTriggered = false;
             errorType = AutomationErrorType.x_runJob_deleteTweets_UnknownError;
 
             success = false;


### PR DESCRIPTION
Fixes #310 

Here's what I believe was happening. `errorTriggered` was set to false, and then there was a for loop looping through each tweet to delete. If one of the tweets triggers an error, `errorTriggered` was set to true... but it was never set to false again. So, if the next tweet did not have an error, it was still set to true.

This fixes just by setting it to false at the beginning of each loop.