### PR TITLE
Rip out the downloadArchive job, and replace it with text instructions

### DIFF
--- a/src/renderer/src/types.ts
+++ b/src/renderer/src/types.ts
@@ -27,6 +27,5 @@ export const PlausibleEvents = Object.freeze({
     X_JOB_STARTED_DELETE_BOOKMARKS: 'X Job Started: deleteBookmarks',
     X_JOB_STARTED_DELETE_DMS: 'X Job Started: deleteDMs',
     X_JOB_STARTED_ARCHIVE_BUILD: 'X Job Started: archiveBuild',
-    X_JOB_STARTED_DOWNLOAD_ARCHIVE: 'X Job Started: downloadArchive',
     X_JOB_STARTED_UNFOLLOW_EVERYONE: 'X Job Started: unfollowEveryone',
 });

--- a/src/renderer/src/views/x/XJobStatusComponent.vue
+++ b/src/renderer/src/views/x/XJobStatusComponent.vue
@@ -21,7 +21,6 @@ const getStatusIcon = (status: string) => {
 const getJobTypeText = (jobType: string) => {
     const jobTypeTexts: { [key: string]: string } = {
         login: 'Logging in',
-        downloadArchive: 'Downloading archive',
         indexTweets: 'Saving tweets',
         indexLikes: 'Saving likes',
         indexBookmarks: 'Saving bookmarks',

--- a/src/renderer/src/views/x/XWizardImportPage.vue
+++ b/src/renderer/src/views/x/XWizardImportPage.vue
@@ -5,9 +5,10 @@ import {
 } from '../../view_models/AccountXViewModel'
 
 import XLastImportOrBuildComponent from './XLastImportOrBuildComponent.vue';
+import { openURL } from '../../util';
 
 // Props
-const props = defineProps<{
+defineProps<{
     model: AccountXViewModel;
 }>();
 
@@ -17,11 +18,6 @@ const emit = defineEmits<{
 }>()
 
 // Buttons
-
-const downloadClicked = async () => {
-    await props.model.defineJobsDownloadArchive();
-    emit('setState', State.RunJobs);
-};
 
 const importClicked = async () => {
     emit('setState', State.WizardImporting);
@@ -39,39 +35,63 @@ const backClicked = async () => {
                 Import your X archive
             </h2>
             <p class="text-muted">
-                Before you can import your X archive, you need to download it. Have you already done
-                this?
+                Before you can import your X archive, you need to download it by following these steps:
             </p>
+            <ul class="x-archive-steps">
+                <li>
+                    <strong>Visit <a href="#" @click="openURL('https://x.com/settings/download_your_data')">
+                            https://x.com/settings/download_your_data</a>.</strong><br>
+                    <small class="text-muted">You might need to sign in to X first.</small>
+                </li>
+                <li>
+                    <strong>Prove your identity.</strong><br>
+                    <small class="text-muted">You'll probably need to type your X password. You might also need to get
+                        a verification code sent to your email, or do other things to verify your identity.</small>
+                </li>
+                <li>
+                    <strong>Click the "Request archive" button.</strong>
+                </li>
+                <li>
+                    <strong>Be patient.</strong><br>
+                    <small class="text-muted">After requesting your archive, you'll need to wait <strong>at least a
+                            day</strong>, and maybe longer. Sorry!</small>
+                </li>
+                <li>
+                    <strong>When it's ready, download the ZIP file from X.</strong><br>
+                    <small class="text-muted">After you've followed these steps and you have your archive ZIP file,
+                        click the button below.</small>
+                </li>
+            </ul>
 
             <div class="buttons mb-4">
                 <button type="submit" class="btn btn-primary text-nowrap m-1" :disabled="!(
                     model.account?.xAccount?.archiveTweets ||
                     model.account?.xAccount?.archiveLikes ||
-                    model.account?.xAccount?.archiveDMs)" @click="downloadClicked">
-                    <i class="fa-solid fa-download" />
-                    Help Me Download My Archive
-                </button>
-                <button type="submit" class="btn btn-primary text-nowrap m-1" :disabled="!(
-                    model.account?.xAccount?.archiveTweets ||
-                    model.account?.xAccount?.archiveLikes ||
                     model.account?.xAccount?.archiveDMs)" @click="importClicked">
-                    <i class="fa-solid fa-folder-tree" />
-                    I Have My Archive
+                    <i class="fa-solid fa-file-import" />
+                    I've Downloaded My Archive from X
+                </button>
+
+                <button type="submit" class="btn btn-outline-secondary text-nowrap m-1" @click="backClicked">
+                    <i class="fa-solid fa-backward" />
+                    Back to Import or Build Database
                 </button>
             </div>
 
             <XLastImportOrBuildComponent :account-i-d="model.account.id" :button-text="'Go to Delete Options'"
                 :button-text-no-data="'Skip to Delete Options'" :button-state="State.WizardDeleteOptions"
                 @set-state="emit('setState', $event)" />
-
-            <div class="buttons">
-                <button type="submit" class="btn btn-outline-secondary text-nowrap m-1" @click="backClicked">
-                    <i class="fa-solid fa-backward" />
-                    Back to Import or Build Database
-                </button>
-            </div>
         </div>
     </div>
 </template>
 
-<style scoped></style>
+<style scoped>
+ul.x-archive-steps {
+    list-style-type: none;
+    padding: 0 1em;
+}
+
+ul.x-archive-steps li {
+    margin-bottom: 1em;
+}
+</style>


### PR DESCRIPTION
Fixes #359 

Trying to download the archive within the webview is fine a lot of the time, but when it's not it can be very confusing. If it doesn't download for any reason (like an error message or redirection on X's side), the user interface still says "Downloading archive" in the status component (because that's the step it's on) and it's not clear what the user should be doing.

I recently helped a celebrity with 2M followers on X try to download his archive, and it just wouldn't work for him. During the step to prove your identity, it told him he had to contact X support, and there was a link that he couldn't click within Cyd because it was set to `target="_blank"`, which Cyd ignores.

This PR bypasses all of these issues, and simplifies the app a little, by replacing the automatic stuff with some simple instructions:

![Screenshot 2025-01-06 at 2 49 14 PM](https://github.com/user-attachments/assets/36507c62-afaf-49e7-b246-4f6d501f7edc)

