### PR TITLE
if logged in, update user activity

### DIFF
--- a/src/cyd-api-client.ts
+++ b/src/cyd-api-client.ts
@@ -567,4 +567,22 @@ export default class CydAPIClient {
             return this.returnError("Failed to subscribe to newsletter. Maybe the server is down?")
         }
     }
+
+    // User activity
+
+    async postUserActivity(): Promise<boolean | APIErrorResponse> {
+        if (!await this.validateAPIToken()) {
+            return this.returnError("Failed to get a new API token.")
+        }
+
+        try {
+            const response = await this.fetchAuthenticated("POST", `${this.apiURL}/user/activity`, null);
+            if (response.status != 200) {
+                return this.returnError("Failed to update user activity.", response.status)
+            }
+            return true;
+        } catch {
+            return this.returnError("Failed to update user activity. Maybe the server is down?")
+        }
+    }
 }

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -84,6 +84,35 @@ emitter?.on('show-advanced-settings', () => {
   showAdvancedSettingsModal.value = true;
 });
 
+// Track whether a user is actively using Cyd
+const updateUserActivity = async () => {
+  if (isSignedIn.value) {
+    try {
+      await apiClient.value.postUserActivity();
+    } catch (error) {
+      console.error("Failed to update user activity:", error);
+    }
+  }
+};
+
+// Update user activity periodically (every 6 hours)
+let userActivityInterval: NodeJS.Timeout | null = null;
+
+const startUserActivityInterval = () => {
+  if (userActivityInterval) {
+    clearInterval(userActivityInterval);
+  }
+  // Update every 6 hours (6 * 60 * 60 * 1000 = 21600000 ms)
+  userActivityInterval = setInterval(updateUserActivity, 21600000);
+};
+
+// Stop the interval when signing out
+emitter?.on('signed-out', () => {
+  if (userActivityInterval) {
+    clearInterval(userActivityInterval);
+    userActivityInterval = null;
+  }
+});
 
 onMounted(async () => {
   await window.electron.trackEvent(PlausibleEvents.APP_OPENED, navigator.userAgent);
@@ -100,11 +129,8 @@ onMounted(async () => {
 
   // If logged in, update the server with user activity (gets truncated to day)
   if (isSignedIn.value) {
-    try {
-      await apiClient.value.postUserActivity();
-    } catch (error) {
-      console.error("Failed to update user activity:", error);
-    }
+    await updateUserActivity();
+    startUserActivityInterval();
   }
 
   isReady.value = true;

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -96,7 +96,7 @@ const updateUserActivity = async () => {
 };
 
 // Update user activity periodically (every 6 hours)
-let userActivityInterval: NodeJS.Timeout | null = null;
+let userActivityInterval: ReturnType<typeof setTimeout> | null = null;
 
 const startUserActivityInterval = () => {
   if (userActivityInterval) {

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -98,6 +98,15 @@ onMounted(async () => {
     isSignedIn.value = true;
   }
 
+  // If logged in, update the server with user activity (gets truncated to day)
+  if (isSignedIn.value) {
+    try {
+      await apiClient.value.postUserActivity();
+    } catch (error) {
+      console.error("Failed to update user activity:", error);
+    }
+  }
+
   isReady.value = true;
 
   // Change the app title

--- a/src/renderer/src/modals/SignInModal.vue
+++ b/src/renderer/src/modals/SignInModal.vue
@@ -157,6 +157,9 @@ async function registerDevice() {
     signInState.value = 'token';
     hide();
 
+    // Update user activity immediately after successful sign in
+    await apiClient.value.postUserActivity();
+
     // Emit the signed-in event
     emitter?.emit('signed-in');
 }


### PR DESCRIPTION
This PR updates the Cyd server with usage data in compliance with Lockdown Systems' Privacy Policy. An API request gets sent after the Plausible analytics data to Cyd server:

When you run this PR against https://github.com/lockdown-systems/cyd-server/pull/128 you'll see:

```
api-1         | 02-17 20:45 werkzeug     INFO     172.19.0.1 - - [17/Feb/2025 20:45:30] "POST /user/activity HTTP/1.1" 200 -
```