### PR TITLE
Add more information about your tweets before you migrate to Bluesky

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/cheerio": "^0.22.35",
         "better-sqlite3": "^11.2.1",
         "bootstrap": "^5.3.3",
+        "chart.js": "^4.4.8",
         "cheerio": "^1.0.0-rc.12",
         "date-fns": "^4.1.0",
         "electron-log": "^5.1.4",
@@ -34,7 +35,8 @@
         "moment": "^2.30.1",
         "unzipper": "^0.12.3",
         "update-electron-app": "^3.0.0",
-        "vue": "^3.4.21"
+        "vue": "^3.4.21",
+        "vue-chartjs": "^5.3.2"
       },
       "devDependencies": {
         "@electron-forge/cli": "7.4.0",
@@ -3167,6 +3169,12 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
@@ -6553,6 +6561,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.8.tgz",
+      "integrity": "sha512-IkGZlVpXP+83QpMm4uxEiGqSI7jFizwVtF3+n5Pc3k7sMO+tkd0qxh2OzLhenM0K80xtmAONWGBn082EiBQSDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/check-error": {
@@ -18148,6 +18168,16 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-chartjs": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.2.tgz",
+      "integrity": "sha512-NrkbRRoYshbXbWqJkTN6InoDVwVb90C0R7eAVgMWcB9dPikbruaOoTFjFYHE/+tNPdIe6qdLCDjfjPHQ0fw4jw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "vue": "^3.0.0-0 || ^2.7.0"
       }
     },
     "node_modules/vue-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/cheerio": "^0.22.35",
     "better-sqlite3": "^11.2.1",
     "bootstrap": "^5.3.3",
+    "chart.js": "^4.4.8",
     "cheerio": "^1.0.0-rc.12",
     "date-fns": "^4.1.0",
     "electron-log": "^5.1.4",
@@ -57,7 +58,8 @@
     "moment": "^2.30.1",
     "unzipper": "^0.12.3",
     "update-electron-app": "^3.0.0",
-    "vue": "^3.4.21"
+    "vue": "^3.4.21",
+    "vue-chartjs": "^5.3.2"
   },
   "devDependencies": {
     "@electron-forge/cli": "7.4.0",

--- a/src/account_x/x_account_controller.ts
+++ b/src/account_x/x_account_controller.ts
@@ -2538,6 +2538,23 @@ export class XAccountController {
         const username = this.account.username;
         const userID = this.account.userID;
 
+        const totalTweets: Sqlite3Count = exec(this.db, `
+            SELECT COUNT(*) AS count
+            FROM tweet
+            WHERE tweet.isLiked = ?
+            AND tweet.username = ?
+            AND tweet.deletedTweetAt IS NULL
+        `, [0, username], "get") as Sqlite3Count;
+
+        const totalRetweets: Sqlite3Count = exec(this.db, `
+            SELECT COUNT(*) AS count
+            FROM tweet
+            WHERE tweet.text LIKE ?
+            AND tweet.isLiked = ?
+            AND tweet.username = ?
+            AND tweet.deletedTweetAt IS NULL
+        `, ["RT @%", 0, username], "get") as Sqlite3Count;
+
         const toMigrateTweets: XTweetRow[] = exec(this.db, `
             SELECT tweet.*
             FROM tweet
@@ -2576,6 +2593,8 @@ export class XAccountController {
 
         // Return the counts
         const resp: XMigrateTweetCounts = {
+            totalTweetsCount: totalTweets.count,
+            totalRetweetsCount: totalRetweets.count,
             toMigrateTweetIDs: toMigrateTweetIDs,
             cannotMigrateCount: cannotMigrate.count,
             alreadyMigratedTweetIDs: alreadyMigratedTweetIDs,

--- a/src/shared_types/x.ts
+++ b/src/shared_types/x.ts
@@ -286,6 +286,8 @@ export interface XImportArchiveResponse {
 // Migration types
 
 export type XMigrateTweetCounts = {
+    totalTweetsCount: number;
+    totalRetweetsCount: number;
     toMigrateTweetIDs: string[];
     cannotMigrateCount: number;
     alreadyMigratedTweetIDs: string[];


### PR DESCRIPTION
One tester pointed out it was confusing that only a relatively small number of tweets could be migrated compared to the estimate of the total tweets in the right sidebar.

This PR adds chart.js to graph the tweets and explain what can and can't be migrated. It tells you the total number of tweets in the local database, how many have already been migrated, how many are retweets, and how many are replies to other users.

Also, it's pretty. Since this adds chart.js, I'd be into adding data viz all over where it's appropriate.

![Screenshot 2025-02-25 at 10 29 29 AM](https://github.com/user-attachments/assets/d3aac4c8-d485-4f40-b4b1-9eb60d65944c)
