### PR TITLE
Fixes gif downloading when building the archive

### DIFF
--- a/archive-static-sites/x-archive/src/components/TweetComponent.vue
+++ b/archive-static-sites/x-archive/src/components/TweetComponent.vue
@@ -61,7 +61,7 @@ function atUriToBlueskyUrl(atUri: string): string {
             <!-- Media -->
             <div v-if="tweet.media.length > 0">
                 <div v-for="media in tweet.media" v-bind:key="media.filename" class="mt-2">
-                    <template v-if="media.mediaType == 'video'">
+                    <template v-if="media.mediaType === 'video' || media.mediaType === 'animated_gif'">
                         <video controls class="img-fluid">
                             <source :src="`./Tweet Media/${media.filename}`" type="video/mp4" />
                         </video>

--- a/src/account_x.test.ts
+++ b/src/account_x.test.ts
@@ -759,6 +759,19 @@ test("XAccountController.indexParsedTweets() should index and download media", a
     expect(mediaRows[0].startIndex).toBe(29);
     expect(mediaRows[0].endIndex).toBe(52);
 
+    // Verify the GIF tweet
+    tweetRows = database.exec(controller.db, "SELECT * FROM tweet WHERE tweetID=?", ['1895432678377398407'], "all") as XTweetRow[];
+    expect(tweetRows.length).toBe(1);
+    expect(tweetRows[0].tweetID).toBe('1895432678377398407');
+    expect(tweetRows[0].text).toBe("It's Friyay!!! https://t.co/bEGcNKradC");
+
+    mediaRows = database.exec(controller.db, "SELECT * FROM tweet_media WHERE tweetID=?", ['1895432678377398407'], "all") as XTweetMediaRow[];
+    expect(mediaRows.length).toBe(1);
+    expect(mediaRows[0].mediaType).toBe('animated_gif');
+    expect(mediaRows[0].filename).toBe('16_1895432668990382080.mp4');
+    expect(mediaRows[0].startIndex).toBe(15);
+    expect(mediaRows[0].endIndex).toBe(38);
+
     // Verify the image tweet
     tweetRows = database.exec(controller.db, "SELECT * FROM tweet WHERE tweetID=?", ['1890512076189114426'], "all") as XTweetRow[];
     expect(tweetRows.length).toBe(1);

--- a/testdata/XAPIUserTweetsAndRepliesMedia.json
+++ b/testdata/XAPIUserTweetsAndRepliesMedia.json
@@ -13,6 +13,258 @@
                                 "type": "TimelineAddEntries",
                                 "entries": [
                                     {
+                                        "entryId": "tweet-1895432678377398407",
+                                        "sortIndex": "7327939358477377400",
+                                        "content": {
+                                            "entryType": "TimelineTimelineItem",
+                                            "__typename": "TimelineTimelineItem",
+                                            "itemContent": {
+                                                "itemType": "TimelineTweet",
+                                                "__typename": "TimelineTweet",
+                                                "tweet_results": {
+                                                    "result": {
+                                                        "__typename": "Tweet",
+                                                        "rest_id": "1895432678377398407",
+                                                        "has_birdwatch_notes": false,
+                                                        "core": {
+                                                            "user_results": {
+                                                                "result": {
+                                                                    "__typename": "User",
+                                                                    "id": "VXNlcjoxODY3MTQ3MTUwNjQxMzAzNTUy",
+                                                                    "rest_id": "1867147150641303552",
+                                                                    "affiliates_highlighted_label": {},
+                                                                    "has_graduated_access": true,
+                                                                    "parody_commentary_fan_label": "None",
+                                                                    "is_blue_verified": false,
+                                                                    "profile_image_shape": "Circle",
+                                                                    "legacy": {
+                                                                        "following": false,
+                                                                        "can_dm": true,
+                                                                        "can_media_tag": true,
+                                                                        "created_at": "Thu Dec 12 09:59:16 +0000 2024",
+                                                                        "default_profile": true,
+                                                                        "default_profile_image": false,
+                                                                        "description": "",
+                                                                        "entities": {
+                                                                            "description": {
+                                                                                "urls": []
+                                                                            }
+                                                                        },
+                                                                        "fast_followers_count": 0,
+                                                                        "favourites_count": 6,
+                                                                        "followers_count": 0,
+                                                                        "friends_count": 3,
+                                                                        "has_custom_timelines": false,
+                                                                        "is_translator": false,
+                                                                        "listed_count": 0,
+                                                                        "location": "",
+                                                                        "media_count": 5,
+                                                                        "name": "Tid Cowman",
+                                                                        "needs_phone_verification": false,
+                                                                        "normal_followers_count": 0,
+                                                                        "pinned_tweet_ids_str": [],
+                                                                        "possibly_sensitive": false,
+                                                                        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1867147512039305217/s3nJWsSI_normal.jpg",
+                                                                        "profile_interstitial_type": "",
+                                                                        "screen_name": "TidCowman",
+                                                                        "statuses_count": 8,
+                                                                        "translator_type": "none",
+                                                                        "verified": false,
+                                                                        "want_retweets": false,
+                                                                        "withheld_in_countries": []
+                                                                    },
+                                                                    "tipjar_settings": {},
+                                                                    "verified_phone_status": false
+                                                                }
+                                                            }
+                                                        },
+                                                        "unmention_data": {},
+                                                        "edit_control": {
+                                                            "edit_tweet_ids": [
+                                                                "1895432678377398407"
+                                                            ],
+                                                            "editable_until_msecs": "1740744940000",
+                                                            "is_edit_eligible": true,
+                                                            "edits_remaining": "5"
+                                                        },
+                                                        "is_translatable": false,
+                                                        "views": {
+                                                            "count": "2",
+                                                            "state": "EnabledWithCount"
+                                                        },
+                                                        "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                        "grok_analysis_button": true,
+                                                        "legacy": {
+                                                            "bookmark_count": 0,
+                                                            "bookmarked": false,
+                                                            "created_at": "Fri Feb 28 11:15:40 +0000 2025",
+                                                            "conversation_id_str": "1895432678377398407",
+                                                            "display_text_range": [
+                                                                0,
+                                                                14
+                                                            ],
+                                                            "entities": {
+                                                                "hashtags": [],
+                                                                "media": [
+                                                                    {
+                                                                        "display_url": "pic.x.com/bEGcNKradC",
+                                                                        "expanded_url": "https://x.com/TidCowman/status/1895432678377398407/photo/1",
+                                                                        "ext_alt_text": "Its Friday Dance GIF by Justin",
+                                                                        "id_str": "1895432668990382080",
+                                                                        "indices": [
+                                                                            15,
+                                                                            38
+                                                                        ],
+                                                                        "media_key": "16_1895432668990382080",
+                                                                        "media_url_https": "https://pbs.twimg.com/tweet_video_thumb/Gk3t-FLXoAAfrpA.jpg",
+                                                                        "type": "animated_gif",
+                                                                        "url": "https://t.co/bEGcNKradC",
+                                                                        "ext_media_availability": {
+                                                                            "status": "Available"
+                                                                        },
+                                                                        "sizes": {
+                                                                            "large": {
+                                                                                "h": 480,
+                                                                                "w": 398,
+                                                                                "resize": "fit"
+                                                                            },
+                                                                            "medium": {
+                                                                                "h": 480,
+                                                                                "w": 398,
+                                                                                "resize": "fit"
+                                                                            },
+                                                                            "small": {
+                                                                                "h": 480,
+                                                                                "w": 398,
+                                                                                "resize": "fit"
+                                                                            },
+                                                                            "thumb": {
+                                                                                "h": 150,
+                                                                                "w": 150,
+                                                                                "resize": "crop"
+                                                                            }
+                                                                        },
+                                                                        "original_info": {
+                                                                            "height": 480,
+                                                                            "width": 398,
+                                                                            "focus_rects": []
+                                                                        },
+                                                                        "video_info": {
+                                                                            "aspect_ratio": [
+                                                                                199,
+                                                                                240
+                                                                            ],
+                                                                            "variants": [
+                                                                                {
+                                                                                    "bitrate": 0,
+                                                                                    "content_type": "video/mp4",
+                                                                                    "url": "https://video.twimg.com/tweet_video/Gk3t-FLXoAAfrpA.mp4"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "media_results": {
+                                                                            "result": {
+                                                                                "media_key": "16_1895432668990382080"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ],
+                                                                "symbols": [],
+                                                                "timestamps": [],
+                                                                "urls": [],
+                                                                "user_mentions": []
+                                                            },
+                                                            "extended_entities": {
+                                                                "media": [
+                                                                    {
+                                                                        "display_url": "pic.x.com/bEGcNKradC",
+                                                                        "expanded_url": "https://x.com/TidCowman/status/1895432678377398407/photo/1",
+                                                                        "ext_alt_text": "Its Friday Dance GIF by Justin",
+                                                                        "id_str": "1895432668990382080",
+                                                                        "indices": [
+                                                                            15,
+                                                                            38
+                                                                        ],
+                                                                        "media_key": "16_1895432668990382080",
+                                                                        "media_url_https": "https://pbs.twimg.com/tweet_video_thumb/Gk3t-FLXoAAfrpA.jpg",
+                                                                        "type": "animated_gif",
+                                                                        "url": "https://t.co/bEGcNKradC",
+                                                                        "ext_media_availability": {
+                                                                            "status": "Available"
+                                                                        },
+                                                                        "sizes": {
+                                                                            "large": {
+                                                                                "h": 480,
+                                                                                "w": 398,
+                                                                                "resize": "fit"
+                                                                            },
+                                                                            "medium": {
+                                                                                "h": 480,
+                                                                                "w": 398,
+                                                                                "resize": "fit"
+                                                                            },
+                                                                            "small": {
+                                                                                "h": 480,
+                                                                                "w": 398,
+                                                                                "resize": "fit"
+                                                                            },
+                                                                            "thumb": {
+                                                                                "h": 150,
+                                                                                "w": 150,
+                                                                                "resize": "crop"
+                                                                            }
+                                                                        },
+                                                                        "original_info": {
+                                                                            "height": 480,
+                                                                            "width": 398,
+                                                                            "focus_rects": []
+                                                                        },
+                                                                        "video_info": {
+                                                                            "aspect_ratio": [
+                                                                                199,
+                                                                                240
+                                                                            ],
+                                                                            "variants": [
+                                                                                {
+                                                                                    "bitrate": 0,
+                                                                                    "content_type": "video/mp4",
+                                                                                    "url": "https://video.twimg.com/tweet_video/Gk3t-FLXoAAfrpA.mp4"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "media_results": {
+                                                                            "result": {
+                                                                                "media_key": "16_1895432668990382080"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "favorite_count": 0,
+                                                            "favorited": false,
+                                                            "full_text": "It's Friyay!!! https://t.co/bEGcNKradC",
+                                                            "is_quote_status": false,
+                                                            "lang": "en",
+                                                            "possibly_sensitive": false,
+                                                            "possibly_sensitive_editable": true,
+                                                            "quote_count": 0,
+                                                            "reply_count": 0,
+                                                            "retweet_count": 0,
+                                                            "retweeted": false,
+                                                            "user_id_str": "1867147150641303552",
+                                                            "id_str": "1895432678377398407"
+                                                        },
+                                                        "quick_promote_eligibility": {
+                                                            "eligibility": "IneligibleNotProfessional"
+                                                        }
+                                                    }
+                                                },
+                                                "tweetDisplayType": "Tweet",
+                                                "hasModeratedReplies": false
+                                            }
+                                        }
+                                    },
+                                    {
                                         "entryId": "tweet-1890513848811090236",
                                         "sortIndex": "1890516651804196864",
                                         "content": {


### PR DESCRIPTION
Fixes #421 

So seems like X saves the GIFs are video files when uploaded (or added from it's interface) as a part of the post. What actually gets rendered is a MP4 file instead of GIF, which is slightly sad since it would have been nice to save a GIF file for migrations elsewhere. However I have gone ahead and made changes to save the MP4 file created by twitter for the GIF.

This should help in storing the video information instead of just a JPG. I have also added tests and modified the local archive template code to render it correctly.