### PR TITLE
Various X bug fixes

### DIFF
--- a/src/account_x.test.ts
+++ b/src/account_x.test.ts
@@ -8,9 +8,7 @@ import {
     XAPILegacyUser,
     XAPILegacyTweet,
     XAPIConversation,
-    XAPIUser
-} from './account_x';
-import {
+    XAPIUser,
     XTweetRow,
     XTweetMediaRow,
     XTweetURLRow,
@@ -18,6 +16,9 @@ import {
     XConversationRow,
     XConversationParticipantRow,
     XMessageRow,
+    isXAPIError,
+    isXAPIBookmarksData,
+    isXAPIData,
 } from './account_x';
 
 // Mock the util module
@@ -801,6 +802,31 @@ test("XAccountController.indexParsedTweets() should index and parse links", asyn
     expect(linkRows[1].expandedURL).toBe('https://en.wikipedia.org/wiki/Sun');
     expect(linkRows[2].expandedURL).toBe('https://x.com/nexamind91326/status/1890513848811090236');
 })
+
+test("types.isXAPIBookmarksData() should recognize bookmarks data", async () => {
+    const body = fs.readFileSync(path.join(__dirname, '..', 'testdata', 'XAPIBookmarks.json'), 'utf8');
+    const data = JSON.parse(body);
+    expect(isXAPIBookmarksData(data)).toBe(true);
+    expect(isXAPIError(data)).toBe(false);
+    expect(isXAPIData(data)).toBe(false);
+})
+
+test("types.isXAPIError() should recognize errors", async () => {
+    const body = fs.readFileSync(path.join(__dirname, '..', 'testdata', 'XAPIUserTweetsAndRepliesError.json'), 'utf8');
+    const data = JSON.parse(body);
+    expect(isXAPIError(data)).toBe(true);
+    expect(isXAPIBookmarksData(data)).toBe(false);
+    expect(isXAPIData(data)).toBe(false);
+})
+
+test("types.isXAPIData() should recognize data", async () => {
+    const body = fs.readFileSync(path.join(__dirname, '..', 'testdata', 'XAPIUserTweetsAndReplies1.json'), 'utf8');
+    const data = JSON.parse(body);
+    expect(isXAPIData(data)).toBe(true);
+    expect(isXAPIBookmarksData(data)).toBe(false);
+    expect(isXAPIError(data)).toBe(false);
+})
+
 
 // Testing the X migrations
 

--- a/src/account_x/types.ts
+++ b/src/account_x/types.ts
@@ -312,6 +312,23 @@ export interface XAPITimeline {
 }
 
 export interface XAPIData {
+    errors?: [
+        {
+            message: string;
+            locations: {
+                line: number;
+                column: number;
+            }[];
+            path: string[];
+            extensions: any;
+            code: number;
+            kind: string;
+            name: string;
+            source: string;
+            retry_after: number;
+            tracing: any;
+        }
+    ],
     data: {
         user: {
             result: {
@@ -329,11 +346,15 @@ export interface XAPIBookmarksData {
 }
 
 export function isXAPIBookmarksData(body: any): body is XAPIBookmarksData {
-    return body.data && body.data.bookmark_timeline_v2;
+    return !!(body.data && body.data.bookmark_timeline_v2);
+}
+
+export function isXAPIError(body: any): body is XAPIData {
+    return !!(body.errors && body.errors.length > 0);
 }
 
 export function isXAPIData(body: any): body is XAPIData {
-    return body.data && body.data.user && body.data.user.result && body.data.user.result.timeline_v2;
+    return !!(body.data && body.data.user && body.data.user.result && body.data.user.result.timeline_v2);
 }
 
 // Index direct messages

--- a/src/account_x/x_account_controller.ts
+++ b/src/account_x/x_account_controller.ts
@@ -87,6 +87,7 @@ import {
     XArchiveLikeContainer,
     isXArchiveLikeContainer,
     isXAPIBookmarksData,
+    isXAPIError,
     isXAPIData,
 } from './types'
 import * as XArchiveTypes from '../../archive-static-sites/x-archive/src/types';
@@ -703,6 +704,10 @@ export class XAccountController {
                 timeline = (body as XAPIBookmarksData).data.bookmark_timeline_v2;
             } else if (isXAPIData(body)) {
                 timeline = (body as XAPIData).data.user.result.timeline_v2;
+            } else if (isXAPIError(body)) {
+                log.error('XAccountController.indexParseTweetsResponseData: XAPIError', body);
+                this.mitmController.responseData[responseIndex].processed = true;
+                return false;
             } else {
                 throw new Error('Invalid response data');
             }

--- a/src/account_x/x_account_controller.ts
+++ b/src/account_x/x_account_controller.ts
@@ -1560,7 +1560,7 @@ export class XAccountController {
             streamWriter.write(',\n');
             await this.writeJSONArray(streamWriter, formattedBookmarks, "bookmarks");
             streamWriter.write(',\n');
-            await this.writeJSONArray(streamWriter, Object.values(formattedUsers), "users");
+            await this.writeJSONObject(streamWriter, formattedUsers, "users");
             streamWriter.write(',\n');
             await this.writeJSONArray(streamWriter, formattedConversations, "conversations");
             streamWriter.write(',\n');
@@ -1590,6 +1590,18 @@ export class XAccountController {
             streamWriter.write('    ' + JSON.stringify(items[i]) + suffix);
         }
         streamWriter.write('  ]');
+    }
+
+    async writeJSONObject(streamWriter: fs.WriteStream, item: object, propertyName: string) {
+        streamWriter.write(`  "${propertyName}": {\n`);
+        const keys = Object.keys(item);
+        for (let i = 0; i < keys.length; i++) {
+            const key = keys[i];
+            const suffix = i < keys.length - 1 ? ',\n' : '\n';
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            streamWriter.write(`    "${key}": ${JSON.stringify((item as any)[key])}${suffix}`);
+        }
+        streamWriter.write('  }');
     }
 
     // When you start deleting tweets, return a list of tweets to delete

--- a/src/account_x/x_account_controller.ts
+++ b/src/account_x/x_account_controller.ts
@@ -887,6 +887,11 @@ export class XAccountController {
 
         // Loop over all URL items
         tweetLegacy.entities?.urls.forEach((url: XAPILegacyURL) => {
+            // Make sure we have all of the URL information before importing
+            if (!url["url"] || !url["display_url"] || !url["expanded_url"] || !url["indices"]) {
+                return;
+            }
+
             // Have we seen this URL before?
             const existing: XTweetURLRow[] = exec(this.db, 'SELECT * FROM tweet_url WHERE url = ? AND tweetID = ?', [url["url"], tweetLegacy["id_str"]], "all") as XTweetURLRow[];
             if (existing.length > 0) {
@@ -2378,7 +2383,7 @@ export class XAccountController {
         const filename = `${media["id_str"]}.${mediaExtension}`;
 
         let archiveMediaFilename = null;
-        if ((media.type === "video" || media.type === "animated_gif" ) && media.video_info?.variants) {
+        if ((media.type === "video" || media.type === "animated_gif") && media.video_info?.variants) {
             // For videos, find the highest quality MP4 variant
             const mp4Variants = media.video_info.variants
                 .filter(v => v.content_type === "video/mp4")

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -350,6 +350,11 @@ body {
   opacity: 0.7;
 }
 
+.webview-automation-border.webview-clickable {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 .webview-input-border {
   border: 5px solid #c1fac4;
 }

--- a/src/renderer/src/view_models/XViewModel.ts
+++ b/src/renderer/src/view_models/XViewModel.ts
@@ -1203,13 +1203,16 @@ Hang on while I scroll down to your earliest direct message conversations...`;
 
             // Load the messages page
             await this.loadURLWithRateLimit("https://x.com/messages");
+            this.log("runJobIndexConversations", "loaded messages page, waiting for conversations to load");
+            await this.sleep(2000);
 
             // If the conversations list is empty, there is no search text field
             try {
-                // Wait for the search text field to appear with a 2 second timeout
-                await this.waitForSelector('section input[type="text"]', "https://x.com/messages", 2000);
+                // Wait for the search text field to appear with a 10 second timeout
+                await this.waitForSelector('section input[type="text"]', "https://x.com/messages", 10000);
             } catch (e) {
                 // There are no conversations
+                this.log("runJobIndexConversations", ["no conversations found", e]);
                 await this.waitForLoadingToFinish();
                 this.progress.isIndexConversationsFinished = true;
                 this.progress.conversationsIndexed = 0;
@@ -1292,6 +1295,7 @@ Hang on while I scroll down to your earliest direct message conversations...`;
                 break;
             } else {
                 if (!moreToScroll) {
+                    this.log("runJobIndexConversations", "we scrolled to the bottom but we're not finished, so scroll up a bit to trigger infinite scroll next time");
                     // We scrolled to the bottom but we're not finished, so scroll up a bit to trigger infinite scroll next time
                     await this.sleep(500);
                     await this.scrollUp(1000);

--- a/src/renderer/src/view_models/XViewModel.ts
+++ b/src/renderer/src/view_models/XViewModel.ts
@@ -441,7 +441,6 @@ export class XViewModel extends BaseViewModel {
     async indexTweetsHandleRateLimit(): Promise<boolean> {
         this.log("indexTweetsHandleRateLimit", this.progress);
 
-        this.pause();
         await this.waitForPause();
 
         if (await this.doesSelectorExist('section [data-testid="cellInnerDiv"]')) {

--- a/src/renderer/src/view_models/XViewModel.ts
+++ b/src/renderer/src/view_models/XViewModel.ts
@@ -459,6 +459,19 @@ export class XViewModel extends BaseViewModel {
             //     </div>
             // </section>
 
+            // Check if we get more tweets by scrolling down, even without clicking any buttons
+            let numberOfDivsBefore = await this.countSelectorsFound('section div[data-testid=cellInnerDiv]');
+            await this.sleep(2000);
+            await this.scrollUp(2000);
+            await this.sleep(2000);
+            await this.scrollToBottom();
+            await this.sleep(2000);
+            let numberOfDivsAfter = await this.countSelectorsFound('section div[data-testid=cellInnerDiv]');
+            if (numberOfDivsAfter > numberOfDivsBefore) {
+                // More tweets loaded
+                return true;
+            }
+
             // If the retry button does not exist, try scrolling up and down again to trigger it
             // The retry button should be in the last cellInnerDiv, and it should have only 1 button in it
             if (await this.countSelectorsWithinElementLastFound('main[role="main"] nav[role="navigation"] + section div[data-testid=cellInnerDiv]', 'button') != 1) {
@@ -473,7 +486,7 @@ export class XViewModel extends BaseViewModel {
             }
 
             // Count divs before clicking retry button
-            let numberOfDivsBefore = await this.countSelectorsFound('section div[data-testid=cellInnerDiv]');
+            numberOfDivsBefore = await this.countSelectorsFound('section div[data-testid=cellInnerDiv]');
             if (numberOfDivsBefore > 0) {
                 // The last one is the one with the button
                 numberOfDivsBefore--;
@@ -484,7 +497,7 @@ export class XViewModel extends BaseViewModel {
             await this.sleep(2000);
 
             // Count divs after clicking retry button
-            const numberOfDivsAfter = await this.countSelectorsFound('section div[data-testid=cellInnerDiv]');
+            numberOfDivsAfter = await this.countSelectorsFound('section div[data-testid=cellInnerDiv]');
 
             // If there are more divs after, it means more tweets loaded
             return numberOfDivsAfter > numberOfDivsBefore;

--- a/src/renderer/src/view_models/XViewModel.ts
+++ b/src/renderer/src/view_models/XViewModel.ts
@@ -441,6 +441,7 @@ export class XViewModel extends BaseViewModel {
     async indexTweetsHandleRateLimit(): Promise<boolean> {
         this.log("indexTweetsHandleRateLimit", this.progress);
 
+        this.pause();
         await this.waitForPause();
 
         if (await this.doesSelectorExist('section [data-testid="cellInnerDiv"]')) {

--- a/src/renderer/src/view_models/XViewModel.ts
+++ b/src/renderer/src/view_models/XViewModel.ts
@@ -1204,7 +1204,13 @@ Hang on while I scroll down to your earliest direct message conversations...`;
             // Load the messages page
             await this.loadURLWithRateLimit("https://x.com/messages");
             this.log("runJobIndexConversations", "loaded messages page, waiting for conversations to load");
-            await this.sleep(2000);
+
+            // Just for good measure, scroll down, wait, and scroll back up, to encourage the web page to load conversations
+            await this.sleep(1000);
+            await this.scrollToBottom();
+            await this.sleep(1000);
+            await this.scrollUp(2000);
+            await this.sleep(1000);
 
             // If the conversations list is empty, there is no search text field
             try {

--- a/src/renderer/src/views/x/XJobStatusComponent.vue
+++ b/src/renderer/src/views/x/XJobStatusComponent.vue
@@ -4,10 +4,11 @@ import RunningIcon from '../shared_components/RunningIcon.vue'
 
 defineProps<{
     jobs: XJob[],
-    isPaused: boolean
+    isPaused: boolean,
+    clickingEnabled: boolean,
 }>();
 
-const emit = defineEmits(['onPause', 'onResume', 'onCancel', 'onReportBug']);
+const emit = defineEmits(['onPause', 'onResume', 'onCancel', 'onReportBug', 'onClickingDisabled', 'onClickingEnabled']);
 
 const getStatusIcon = (status: string) => {
     const statusIcons: { [key: string]: string } = {
@@ -67,6 +68,12 @@ const getJobTypeText = (jobType: string) => {
         <div class="d-flex justify-content-center">
             <button class="btn btn-link btn-sm" @click="emit('onReportBug')">
                 Report a Bug
+            </button>
+        </div>
+        <div class="d-flex justify-content-center">
+            <button class="btn btn-link btn-sm"
+                @click="clickingEnabled ? emit('onClickingDisabled') : emit('onClickingEnabled')">
+                {{ clickingEnabled ? 'Disable' : 'Enable' }} Clicking in Browser
             </button>
         </div>
     </div>

--- a/src/renderer/src/views/x/XView.vue
+++ b/src/renderer/src/views/x/XView.vue
@@ -214,6 +214,9 @@ const reloadMediaPath = async () => {
     console.log('mediaPath', mediaPath.value);
 };
 
+// Enable/disable clicking in the webview
+const clickingEnabled = ref(false);
+
 // User variables
 const userAuthenticated = ref(false);
 const userPremium = ref(false);
@@ -458,9 +461,10 @@ onUnmounted(async () => {
                 <div class="d-flex align-items-center">
                     <!-- Job status -->
                     <XJobStatusComponent v-if="currentJobs.length > 0 && model.state == State.RunJobs"
-                        :jobs="currentJobs" :is-paused="isPaused" class="job-status-component" @on-pause="model.pause()"
-                        @on-resume="model.resume()" @on-cancel="emit('onRefreshClicked')"
-                        @on-report-bug="onReportBug" />
+                        :jobs="currentJobs" :is-paused="isPaused" :clicking-enabled="clickingEnabled"
+                        class="job-status-component" @on-pause="model.pause()" @on-resume="model.resume()"
+                        @on-cancel="emit('onRefreshClicked')" @on-report-bug="onReportBug"
+                        @on-clicking-enabled="clickingEnabled = true" @on-clicking-disabled="clickingEnabled = false" />
                 </div>
             </div>
 
@@ -479,7 +483,8 @@ onUnmounted(async () => {
             :class="{
                 'hidden': !model.showBrowser,
                 'webview-automation-border': model.showAutomationNotice,
-                'webview-input-border': !model.showAutomationNotice
+                'webview-input-border': !model.showAutomationNotice,
+                'webview-clickable': clickingEnabled
             }" />
 
         <template v-if="model.state != State.WizardStart">

--- a/testdata/XAPIUserTweetsAndRepliesError.json
+++ b/testdata/XAPIUserTweetsAndRepliesError.json
@@ -1,0 +1,38 @@
+{
+    "errors": [
+        {
+            "message": "Timeout: Unspecified",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 5
+                }
+            ],
+            "path": [
+                "user",
+                "result"
+            ],
+            "extensions": {
+                "name": "TimeoutError",
+                "source": "Server",
+                "retry_after": 0,
+                "code": 29,
+                "kind": "ServiceLevel",
+                "tracing": {
+                    "trace_id": "c685ec3405bf1b67"
+                }
+            },
+            "code": 29,
+            "kind": "ServiceLevel",
+            "name": "TimeoutError",
+            "source": "Server",
+            "retry_after": 0,
+            "tracing": {
+                "trace_id": "c685ec3405bf1b67"
+            }
+        }
+    ],
+    "data": {
+        "user": {}
+    }
+}


### PR DESCRIPTION
Fixes #432.

Also fixes #416, which I just realized was introduced in #384.

I also merged #434 and #430 into this branch, so we should review/merge those first.

For some reason, X returned a tweet (technically a RT) with entities that had `urls` that looked like this:

```
"urls": [
    {
        "display_url": "t.co",
        "url": "https://t.co/",
        "indices": [
            130,
            143
        ]
    }
],
```

While indexing, this now only saves URLs from tweets if all of the correct fields are present.

During indexTweets, X sometimes responds with 429 even when it is not really rated limited. This leads the indexing to stop early because it cannot find the retry button. This PR checks to make sure this is not the case before looking for the retry button, so the indexing doesn't stop early. I think this should make indexing more robust.

There were also various problems I noticed with saving DMs. When trying to save conversations it sometimes would timeout too soon and move to saving messages, so I increased the timeout. I fixed that by increasing the timeout, and also fiddling around with scrolling after the page loads to encourage it to show conversations. It seems to work.

I also added a "Enabling Clicking in Browser" link to the job status component. When you click it, you can click around in the browser during automation. If you click again, you can disable it.

![Screenshot 2025-02-28 at 4 47 39 PM](https://github.com/user-attachments/assets/16f86f24-01c7-4800-b247-23a77dc00917)

It was difficult for me to reproduce, but I did get to a point when indexing DMs where there was a "retry" button that Cyd wasn't clicking and it was stuck, so this allows the user to click it themselves if they want.