### PR TITLE
Add plausible to docs site

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -154,6 +154,9 @@ const config: Config = {
       darkTheme: prismThemes.dracula,
     },
   } satisfies Preset.ThemeConfig,
+  scripts: [
+    { src: 'https://plausible.io/js/script.js', defer: true, 'data-domain': 'docs.cyd.social' }
+  ],
 };
 
 export default config;


### PR DESCRIPTION
So we can get private analytics on how much people are using the docs.