### PR TITLE
Allow bluesky handle input to start with @

### DIFF
--- a/src/account_x/x_account_controller.ts
+++ b/src/account_x/x_account_controller.ts
@@ -2561,6 +2561,11 @@ export class XAccountController {
         }
 
         try {
+            // Check if the handle starts with @. If so, strip the @ and try authorizing
+            if (handle.startsWith("@")) {
+                handle = handle.substring(1);
+            }
+
             // Authorize the handle
             const url = await this.blueskyClient.authorize(handle);
 

--- a/src/renderer/src/views/x/XWizardMigrateBluesky.vue
+++ b/src/renderer/src/views/x/XWizardMigrateBluesky.vue
@@ -57,6 +57,10 @@ const connectClicked = async () => {
     connectButtonText.value = 'Connecting...';
     state.value = State.Connecting;
 
+    if (blueskyHandle.value.startsWith('@')) {
+        blueskyHandle.value = blueskyHandle.value.substring(1);
+    }
+
     try {
         const ret: boolean | string = await window.electron.X.blueskyAuthorize(props.model.account.id, blueskyHandle.value);
         if (ret !== true) {


### PR DESCRIPTION
Fixes #447 

This change just strips the @ from the beginning if the bluesky handle startswith @ and then sends the authorization request with the modified handle.

@micahflee I have not tested this with an actual bluesky account.