### PR TITLE
When loading the DMs page to delete DMs, increase the timeout

### DIFF
--- a/src/renderer/src/view_models/XViewModel.ts
+++ b/src/renderer/src/view_models/XViewModel.ts
@@ -728,8 +728,8 @@ export class XViewModel extends BaseViewModel {
 
             // If the conversations list is empty, there is no search text field
             try {
-                // Wait for the search text field to appear with a 2 second timeout
-                await this.waitForSelector('section input[type="text"]', "https://x.com/messages", 2000);
+                // Wait for the search text field to appear with a 10 second timeout
+                await this.waitForSelector('section input[type="text"]', "https://x.com/messages", 10000);
             } catch (e) {
                 // There are no conversations
                 await this.waitForLoadingToFinish();


### PR DESCRIPTION
When helping someone delete all their many thousands of DMs, I found that a 2 second timeout wasn't enough for the DM conversations to load. This increases it to 10 seconds, which seems to work fine.