### PR TITLE
facebook: add `Delete` and `Archive` options

### DIFF
--- a/src/account_facebook/facebook_account_controller.ts
+++ b/src/account_facebook/facebook_account_controller.ts
@@ -823,6 +823,7 @@ export class FacebookAccountController {
 
         // Count total posts
         const postsSaved: Sqlite3Count = exec(this.db, "SELECT COUNT(*) AS count FROM post", [], "get") as Sqlite3Count;
+        log.info('FacebookAccountController.getDatabaseStats: posts count:', postsSaved);
 
         // Count shared posts (reposts)
         const repostsSaved: Sqlite3Count = exec(this.db,
@@ -830,11 +831,8 @@ export class FacebookAccountController {
             [],
             "get"
         ) as Sqlite3Count;
+        log.info('FacebookAccountController.getDatabaseStats: reposts count:', repostsSaved);
 
-        // TODO: When we start deleting posts, we need to count them up here.
-
-        log.info('FacebookAccountController.getDatabaseStats: postsSaved', postsSaved.count);
-        log.info('FacebookAccountController.getDatabaseStats: repostsSaved', repostsSaved.count);
         databaseStats.postsSaved = postsSaved.count;
         databaseStats.repostsSaved = repostsSaved.count;
         return databaseStats;

--- a/src/account_facebook/facebook_account_controller.ts
+++ b/src/account_facebook/facebook_account_controller.ts
@@ -833,6 +833,8 @@ export class FacebookAccountController {
 
         // TODO: When we start deleting posts, we need to count them up here.
 
+        log.info('FacebookAccountController.getDatabaseStats: postsSaved', postsSaved.count);
+        log.info('FacebookAccountController.getDatabaseStats: repostsSaved', repostsSaved.count);
         databaseStats.postsSaved = postsSaved.count;
         databaseStats.repostsSaved = repostsSaved.count;
         return databaseStats;

--- a/src/account_facebook/ipc.ts
+++ b/src/account_facebook/ipc.ts
@@ -5,6 +5,8 @@ import { FacebookAccountController } from './facebook_account_controller';
 import {
     FacebookJob,
     FacebookProgress,
+    FacebookDatabaseStats,
+    FacebookImportArchiveResponse,
 } from '../shared_types'
 import { getMITMController } from '../mitm';
 import { packageExceptionForReport } from '../util'
@@ -123,7 +125,7 @@ export const defineIPCFacebook = () => {
     ipcMain.handle('Facebook:deleteUnzippedFacebookArchive', async (_, accountID: number, archivePath: string): Promise<string | null> => {
         try {
             const controller = getFacebookAccountController(accountID);
-            await controller.deleteUnzippedFacebookArchive(archivePath);
+            return await controller.deleteUnzippedFacebookArchive(archivePath);
         } catch (error) {
             throw new Error(packageExceptionForReport(error as Error));
         }
@@ -142,6 +144,15 @@ export const defineIPCFacebook = () => {
         try {
             const controller = getFacebookAccountController(accountID);
             return await controller.importFacebookArchive(archivePath, dataType);
+        } catch (error) {
+            throw new Error(packageExceptionForReport(error as Error));
+        }
+    });
+
+    ipcMain.handle('Facebook:getDatabaseStats', async (_, accountID: number): Promise<FacebookDatabaseStats> => {
+        try {
+            const controller = getFacebookAccountController(accountID);
+            return await controller.getDatabaseStats();
         } catch (error) {
             throw new Error(packageExceptionForReport(error as Error));
         }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -21,6 +21,7 @@ import {
     FacebookJob,
     FacebookProgress,
     FacebookImportArchiveResponse,
+    FacebookDatabaseStats,
 } from './shared_types'
 
 contextBridge.exposeInMainWorld('electron', {
@@ -378,6 +379,9 @@ contextBridge.exposeInMainWorld('electron', {
         },
         importFacebookArchive: (accountID: number, archivePath: string, dataType: string): Promise<FacebookImportArchiveResponse> => {
             return ipcRenderer.invoke('Facebook:importFacebookArchive', accountID, archivePath, dataType);
+        },
+        getDatabaseStats: (accountID: number): Promise<FacebookDatabaseStats> => {
+            return ipcRenderer.invoke('Facebook:getDatabaseStats', accountID);
         },
     },
 })

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -27,6 +27,7 @@ import type {
     FacebookProgress,
     FacebookJob,
     FacebookImportArchiveResponse,
+    FacebookDatabaseStats,
 } from "../../shared_types";
 import App from "./App.vue";
 
@@ -157,6 +158,7 @@ declare global {
                 deleteUnzippedFacebookArchive: (accountID: number, archivePath: string) => Promise<string | null>;
                 verifyFacebookArchive: (accountID: number, archivePath: string) => Promise<string | null>;
                 importFacebookArchive: (accountID: number, archivePath: string, dataType: string) => Promise<FacebookImportArchiveResponse>;
+                getDatabaseStats: (accountID: number) => Promise<FacebookDatabaseStats>;
             },
             onPowerMonitorSuspend: (callback: () => void) => Promise<void>;
             onPowerMonitorResume: (callback: () => void) => Promise<void>;

--- a/src/renderer/src/util_facebook.ts
+++ b/src/renderer/src/util_facebook.ts
@@ -2,9 +2,24 @@ import CydAPIClient from '../../cyd-api-client';
 import type { DeviceInfo } from './types';
 import { FacebookAccount } from '../../shared_types';
 
+
+export async function facebookGetLastImportArchive(accountID: number): Promise<Date | null> {
+    const lastFinishedJob_importArchive = await window.electron.Facebook.getConfig(accountID, 'lastFinishedJob_importArchive');
+    if (lastFinishedJob_importArchive) {
+        return new Date(lastFinishedJob_importArchive);
+    }
+    return null;
+}
+
+export async function facebookGetLastBuildDatabase(_accountID: number): Promise<Date | null> {
+    // TODO implement
+    return null;
+}
+
 export async function facebookHasSomeData(_accountID: number): Promise<boolean> {
-    // TODO: implement
-    return false;
+    const lastImportArchive: Date | null = await facebookGetLastImportArchive(_accountID);
+    const lastBuildDatabase: Date | null = await facebookGetLastBuildDatabase(_accountID);
+    return lastImportArchive !== null || lastBuildDatabase !== null;
 }
 
 export async function facebookRequiresPremium(_facebookAccount: FacebookAccount): Promise<boolean> {

--- a/src/renderer/src/view_models/FacebookViewModel.ts
+++ b/src/renderer/src/view_models/FacebookViewModel.ts
@@ -15,8 +15,14 @@ export enum State {
 
     WizardStart = "WizardStart",
 
+    WizardDatabase = "WizardDatabase",
+    WizardDatabaseDisplay = "WizardDatabaseDisplay",
+
     WizardImportOrBuild = "WizardImportOrBuild",
     WizardImportOrBuildDisplay = "WizardImportOrBuildDisplay",
+
+    WizardReview = "WizardReview",
+    WizardReviewDisplay = "WizardReviewDisplay",
 
     WizardImportStart = "WizardImportStart",
     WizardImportStartDisplay = "WizardImportStartDisplay",

--- a/src/renderer/src/view_models/FacebookViewModel.ts
+++ b/src/renderer/src/view_models/FacebookViewModel.ts
@@ -15,8 +15,6 @@ export enum State {
 
     WizardStart = "WizardStart",
 
-    WizardArchiveOptions = "WizardArchiveOptions",
-
     WizardImportOrBuild = "WizardImportOrBuild",
     WizardImportOrBuildDisplay = "WizardImportOrBuildDisplay",
 
@@ -30,7 +28,11 @@ export enum State {
     WizardBuildOptions = "WizardBuildOptions",
     WizardBuildOptionsDisplay = "WizardBuildOptionsDisplay",
 
+    WizardArchiveOptions = "WizardArchiveOptions",
+    WizardArchiveOptionsDisplay = "WizardArchiveOptionsDisplay",
+
     WizardDeleteOptions = "WizardDeleteOptions",
+    WizardDeleteOptionsDisplay = "WizardDeleteOptionsDisplay",
 
     WizardCheckPremium = "WizardCheckPremium",
     WizardCheckPremiumDisplay = "WizardCheckPremiumDisplay",
@@ -544,6 +546,21 @@ You can either import a Facebook archive, or I can build it from scratch by scro
                     this.instructions = `I'll help you import your Facebook archive into your local database.`;
                     await this.loadURL("about:blank");
                     this.state = State.WizardImportingDisplay;
+                    break;
+
+                case State.WizardArchiveOptions:
+                    this.showBrowser = false;
+                    this.instructions = `I'll help you archive your Facebook account.`;
+                    await this.loadURL("about:blank");
+                    this.state = State.WizardArchiveOptionsDisplay;
+                    break;
+
+                case State.WizardDeleteOptions:
+                    this.showBrowser = false;
+                    this.instructions = `
+**Which data do you want to delete?**`;
+                    await this.loadURL("about:blank");
+                    this.state = State.WizardDeleteOptionsDisplay;
                     break;
 
                 case State.Debug:

--- a/src/renderer/src/views/facebook/FacebookView.vue
+++ b/src/renderer/src/views/facebook/FacebookView.vue
@@ -23,6 +23,8 @@ import FacebookWizardSidebar from './FacebookWizardSidebar.vue';
 import FacebookWizardImportPage from './FacebookWizardImportPage.vue';
 import FacebookWizardImportDownloadPage from './FacebookWizardImportDownloadPage.vue';
 import FacebookWizardImportingPage from './FacebookWizardImportingPage.vue';
+import FacebookWizardArchiveOptionsPage from './FacebookWizardArchiveOptionsPage.vue';
+import FacebookWizardDeleteOptionsPage from './FacebookWizardDeleteOptionsPage.vue';
 
 import type {
     Account,
@@ -93,10 +95,10 @@ watch(
     { deep: true, }
 );
 
-// const updateAccount = async () => {
-//     await model.value.reloadAccount();
-//     emitter?.emit('account-updated');
-// };
+const updateAccount = async () => {
+    await model.value.reloadAccount();
+    emitter?.emit('account-updated');
+};
 
 const setState = async (state: State) => {
     console.log('Setting state', state);
@@ -397,6 +399,13 @@ onUnmounted(async () => {
 
                         <FacebookWizardImportingPage v-if="model.state == State.WizardImportingDisplay" :model="unref(model)"
                             @set-state="setState($event)" />
+
+                        <FacebookWizardArchiveOptionsPage v-if="model.state == State.WizardArchiveOptionsDisplay"
+                            :model="unref(model)" @set-state="setState($event)" @update-account="updateAccount" />
+
+                        <FacebookWizardDeleteOptionsPage v-if="model.state == State.WizardDeleteOptionsDisplay"
+                            :model="unref(model)" :user-authenticated="userAuthenticated" :user-premium="userPremium"
+                            @update-account="updateAccount" @set-state="setState($event)" />
 
                         <!-- Debug state -->
                         <div v-if="model.state == State.Debug">

--- a/src/renderer/src/views/facebook/FacebookWizardArchiveOptionsPage.vue
+++ b/src/renderer/src/views/facebook/FacebookWizardArchiveOptionsPage.vue
@@ -108,7 +108,7 @@ onMounted(async () => {
                 <button type="submit" class="btn btn-primary text-nowrap m-1"
                     :disabled="!archivePosts" @click="nextClicked">
                     <i class="fa-solid fa-forward" />
-                    Continue to Review
+                    Continue to Review (NOT IMPL YET)
                 </button>
             </div>
         </form>

--- a/src/renderer/src/views/facebook/FacebookWizardArchiveOptionsPage.vue
+++ b/src/renderer/src/views/facebook/FacebookWizardArchiveOptionsPage.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { FacebookViewModel, State } from '../../view_models/FacebookViewModel'
+import type { FacebookDatabaseStats } from '../../../../shared_types';
+import { emptyFacebookDatabaseStats } from '../../../../shared_types';
+import { setJobsType } from '../../util';
+
+// Props
+const props = defineProps<{
+    model: FacebookViewModel;
+}>();
+
+// Emits
+const emit = defineEmits<{
+    updateAccount: []
+    setState: [value: State]
+}>()
+
+// Buttons
+const nextClicked = async () => {
+    await saveSettings();
+    setJobsType(props.model.account.id, 'archive');
+    emit('setState', State.WizardReview);
+};
+
+const backClicked = async () => {
+    await saveSettings();
+    emit('setState', State.WizardDatabase);
+};
+
+// Settings
+const archivePosts = ref(false);
+
+const databaseStats = ref<FacebookDatabaseStats>(emptyFacebookDatabaseStats());
+
+const loadSettings = async () => {
+    console.log('FacebookWizardArchiveOptionsPage', 'loadSettings');
+    const account = await window.electron.database.getAccount(props.model.account?.id);
+    if (account && account.facebookAccount) {
+        archivePosts.value = account.facebookAccount.savePosts;
+    }
+};
+
+const saveSettings = async () => {
+    console.log('FacebookWizardArchiveOptionsPage', 'saveSettings');
+    if (!props.model.account) {
+        console.error('FacebookWizardArchiveOptionsPage', 'saveSettings', 'account is null');
+        return;
+    }
+    const account = await window.electron.database.getAccount(props.model.account?.id);
+    if (account && account.facebookAccount) {
+        account.facebookAccount.saveMyData = false;
+        account.facebookAccount.deleteMyData = false;
+
+        // account.facebookAccount.archiveMyData = true;
+        // account.facebookAccount.archivePosts = archivePosts.value;
+        await window.electron.database.saveAccount(JSON.stringify(account));
+        emit('updateAccount');
+    }
+};
+
+onMounted(async () => {
+    await loadSettings();
+    databaseStats.value = await window.electron.Facebook.getDatabaseStats(props.model.account.id);
+});
+</script>
+
+<template>
+    <div class="wizard-content container mb-4 mt-3 mx-auto">
+        <div class="mb-4">
+            <h2>
+                Archive options
+            </h2>
+        </div>
+
+        <form @submit.prevent>
+            <div class="mb-3">
+                <div class="indent">
+                    <small v-if="databaseStats.postsSaved == 0" class="form-text text-muted">
+                        <i class="fa-solid fa-triangle-exclamation" />
+                        Your local database doesn't have any posts yet. You need to import your Facebook archive or
+                        build your database from scratch.
+                    </small>
+                </div>
+            </div>
+
+            <div class="buttons">
+                <button type="submit" class="btn btn-outline-secondary text-nowrap m-1" @click="backClicked">
+                    <i class="fa-solid fa-backward" />
+                    Back to Import or Build Database
+                </button>
+
+                <button type="submit" class="btn btn-primary text-nowrap m-1"
+                    :disabled="!archivePosts" @click="nextClicked">
+                    <i class="fa-solid fa-forward" />
+                    Continue to Review
+                </button>
+            </div>
+        </form>
+    </div>
+</template>
+
+<style scoped></style>

--- a/src/renderer/src/views/facebook/FacebookWizardArchiveOptionsPage.vue
+++ b/src/renderer/src/views/facebook/FacebookWizardArchiveOptionsPage.vue
@@ -17,7 +17,7 @@ const emit = defineEmits<{
 }>()
 
 // Settings
-const archivePosts = ref(true);  // Default to true since this is the main action
+const archivePosts = ref(true);
 const databaseStats = ref<FacebookDatabaseStats>(emptyFacebookDatabaseStats());
 
 const loadSettings = async () => {
@@ -26,6 +26,8 @@ const loadSettings = async () => {
     if (account && account.facebookAccount) {
         archivePosts.value = account.facebookAccount.savePosts ?? true;
     }
+    // Load database stats
+    databaseStats.value = await window.electron.Facebook.getDatabaseStats(props.model.account.id);
 };
 
 const saveSettings = async () => {
@@ -53,12 +55,11 @@ const nextClicked = async () => {
 
 const backClicked = async () => {
     await saveSettings();
-    emit('setState', State.WizardDatabase);
+    emit('setState', State.WizardImporting);
 };
 
 onMounted(async () => {
     await loadSettings();
-    databaseStats.value = await window.electron.Facebook.getDatabaseStats(props.model.account.id);
 });
 </script>
 

--- a/src/renderer/src/views/facebook/FacebookWizardArchiveOptionsPage.vue
+++ b/src/renderer/src/views/facebook/FacebookWizardArchiveOptionsPage.vue
@@ -26,8 +26,6 @@ const loadSettings = async () => {
     if (account && account.facebookAccount) {
         archivePosts.value = account.facebookAccount.savePosts ?? true;
     }
-    // Load database stats
-    databaseStats.value = await window.electron.Facebook.getDatabaseStats(props.model.account.id);
 };
 
 const saveSettings = async () => {
@@ -60,6 +58,8 @@ const backClicked = async () => {
 
 onMounted(async () => {
     await loadSettings();
+    const stats = await window.electron.Facebook.getDatabaseStats(props.model.account.id);
+    databaseStats.value = stats;
 });
 </script>
 
@@ -74,18 +74,18 @@ onMounted(async () => {
         <form @submit.prevent>
             <div class="mb-3">
                 <div class="indent">
-                    <small v-if="databaseStats.postsSaved == 0" class="form-text text-muted">
-                        <i class="fa-solid fa-triangle-exclamation" />
-                        Your local database doesn't have any posts yet. You need to import your Facebook archive or
-                        build your database from scratch.
-                    </small>
-                    <div v-else>
+                    <div v-if="databaseStats.postsSaved > 0">
                         <p>Current database stats:</p>
                         <ul class="list-unstyled">
                             <li><i class="fa-solid fa-file-lines me-2"></i>Posts saved: {{ databaseStats.postsSaved }}</li>
                             <li><i class="fa-solid fa-share me-2"></i>Shared posts: {{ databaseStats.repostsSaved }}</li>
                         </ul>
                     </div>
+                    <small v-else class="form-text text-muted">
+                        <i class="fa-solid fa-triangle-exclamation" />
+                        Your local database doesn't have any posts yet. You need to import your Facebook archive or
+                        build your database from scratch.
+                    </small>
                 </div>
             </div>
 

--- a/src/renderer/src/views/facebook/FacebookWizardDeleteOptionsPage.vue
+++ b/src/renderer/src/views/facebook/FacebookWizardDeleteOptionsPage.vue
@@ -91,9 +91,9 @@ const saveSettings = async () => {
     }
     const account = await window.electron.database.getAccount(props.model.account?.id);
     if (account && account.facebookAccount) {
-        account.facebookAccount.saveMyData = false;
-        account.facebookAccount.deleteMyData = true;
-        account.facebookAccount.archiveMyData = false;
+        // account.facebookAccount.saveMyData = false;
+        // account.facebookAccount.deleteMyData = true;
+        // account.facebookAccount.archiveMyData = false;
 
         account.facebookAccount.deletePosts = deletePosts.value;
         account.facebookAccount.deletePostsDaysOldEnabled = deletePostsDaysOldEnabled.value;

--- a/src/renderer/src/views/facebook/FacebookWizardDeleteOptionsPage.vue
+++ b/src/renderer/src/views/facebook/FacebookWizardDeleteOptionsPage.vue
@@ -25,6 +25,11 @@ const emit = defineEmits<{
 }>()
 
 // Buttons
+const backClicked = async () => {
+    await saveSettings();
+    emit('setState', State.WizardImporting);
+};
+
 const nextClicked = async () => {
     await saveSettings();
     setJobsType(props.model.account.id, 'delete');
@@ -131,7 +136,7 @@ onMounted(async () => {
             </p>
         </div>
 
-        <XLastImportOrBuildComponent :account-i-d="model.account.id" :show-button="true" :show-no-data-warning="true"
+        <FacebookLastImportOrBuildComponent :account-i-d="model.account.id" :show-button="true" :show-no-data-warning="true"
             :button-text="'Build Your Local Database'" :button-state="State.WizardDatabase"
             @set-state="emit('setState', $event)" />
 
@@ -228,6 +233,11 @@ onMounted(async () => {
             </div>
 
             <div class="buttons">
+                <button type="submit" class="btn btn-outline-secondary text-nowrap m-1" @click="backClicked">
+                    <i class="fa-solid fa-backward" />
+                    Back to Import or Build Database
+                </button>
+
                 <button type="submit" class="btn btn-primary text-nowrap m-1"
                     :disabled="(hasSomeData && !(deletePosts || deleteReposts))"
                     @click="nextClicked">

--- a/src/renderer/src/views/facebook/FacebookWizardDeleteOptionsPage.vue
+++ b/src/renderer/src/views/facebook/FacebookWizardDeleteOptionsPage.vue
@@ -242,7 +242,7 @@ onMounted(async () => {
                     :disabled="(hasSomeData && !(deletePosts || deleteReposts))"
                     @click="nextClicked">
                     <i class="fa-solid fa-forward" />
-                    Continue to Review
+                    Continue to Review (NOT IMPL YET)
                 </button>
             </div>
         </form>

--- a/src/renderer/src/views/facebook/FacebookWizardDeleteOptionsPage.vue
+++ b/src/renderer/src/views/facebook/FacebookWizardDeleteOptionsPage.vue
@@ -1,0 +1,250 @@
+<script setup lang="ts">
+import {
+    ref,
+    onMounted,
+    computed,
+} from 'vue';
+import {
+    FacebookViewModel,
+    State
+} from '../../view_models/FacebookViewModel'
+import { facebookHasSomeData } from '../../util_facebook';
+import { setJobsType } from '../../util';
+
+// Props
+const props = defineProps<{
+    model: FacebookViewModel;
+    userAuthenticated: boolean;
+    userPremium: boolean;
+}>();
+
+// Emits
+const emit = defineEmits<{
+    updateAccount: []
+    setState: [value: State]
+}>()
+
+// Buttons
+const nextClicked = async () => {
+    await saveSettings();
+    setJobsType(props.model.account.id, 'delete');
+    emit('setState', State.WizardReview);
+};
+
+// Show more
+const deletePostsShowMore = ref(false);
+const deletePostsShowMoreButtonText = computed(() => deletePostsShowMore.value ? 'Hide more options' : 'Show more options');
+const deletePostsShowMoreClicked = () => {
+    deletePostsShowMore.value = !deletePostsShowMore.value;
+};
+
+const deleteRepostsShowMore = ref(false);
+const deleteRepostsShowMoreButtonText = computed(() => deleteRepostsShowMore.value ? 'Hide more options' : 'Show more options');
+const deleteRepostsShowMoreClicked = () => {
+    deleteRepostsShowMore.value = !deleteRepostsShowMore.value;
+};
+
+// Settings
+// TODO: Add more deletion options here based on available data
+const deletePosts = ref(false);
+const deletePostsDaysOldEnabled = ref(false);
+const deletePostsDaysOld = ref(0);
+const deleteReposts = ref(false);
+const deleteRepostsDaysOldEnabled = ref(false);
+const deleteRepostsDaysOld = ref(0);
+
+
+const loadSettings = async () => {
+    console.log('FacebookWizardDeleteOptionsPage', 'loadSettings');
+    const account = await window.electron.database.getAccount(props.model.account?.id);
+    if (account && account.facebookAccount) {
+        deletePosts.value = account.facebookAccount.deletePosts;
+        deletePostsDaysOld.value = account.facebookAccount.deletePostsDaysOld;
+        deletePostsDaysOldEnabled.value = account.facebookAccount.deletePostsDaysOldEnabled;
+        deleteReposts.value = account.facebookAccount.deleteReposts;
+        deleteRepostsDaysOld.value = account.facebookAccount.deleteRepostsDaysOld;
+        deleteRepostsDaysOldEnabled.value = account.facebookAccount.deleteRepostsDaysOldEnabled;
+    }
+
+    // Should delete posts show more options?
+    if (
+        deletePosts.value &&
+        (
+            deletePostsDaysOldEnabled.value ||
+            deleteRepostsDaysOldEnabled.value
+        )
+    ) {
+        deletePostsShowMore.value = true;
+    }
+
+    // Should delete reposts show more options?
+    if (deleteReposts.value && deleteRepostsDaysOldEnabled.value) {
+        deleteRepostsShowMore.value = true;
+    }
+};
+
+const saveSettings = async () => {
+    console.log('FacebookWizardDeleteOptionsPage', 'saveSettings');
+    if (!props.model.account) {
+        console.error('FacebookWizardDeleteOptionsPage', 'saveSettings', 'account is null');
+        return;
+    }
+    const account = await window.electron.database.getAccount(props.model.account?.id);
+    if (account && account.facebookAccount) {
+        account.facebookAccount.saveMyData = false;
+        account.facebookAccount.deleteMyData = true;
+        account.facebookAccount.archiveMyData = false;
+
+        account.facebookAccount.deletePosts = deletePosts.value;
+        account.facebookAccount.deletePostsDaysOldEnabled = deletePostsDaysOldEnabled.value;
+        account.facebookAccount.deletePostsDaysOld = deletePostsDaysOld.value;
+        account.facebookAccount.deleteReposts = deleteReposts.value;
+        account.facebookAccount.deleteRepostsDaysOldEnabled = deleteRepostsDaysOldEnabled.value;
+        account.facebookAccount.deleteRepostsDaysOld = deleteRepostsDaysOld.value;
+
+        await window.electron.database.saveAccount(JSON.stringify(account));
+        emit('updateAccount');
+    }
+};
+
+const hasSomeData = ref(false);
+
+onMounted(async () => {
+    await loadSettings();
+    hasSomeData.value = await facebookHasSomeData(props.model.account.id);
+
+    if (!hasSomeData.value) {
+        deletePosts.value = false;
+        deleteReposts.value = false;
+    }
+});
+</script>
+
+<template>
+    <div class="wizard-content container mb-4 mt-3 mx-auto">
+        <div class="mb-4">
+            <h2>
+                Delete from Facebook
+            </h2>
+            <p class="text-muted">
+                Delete your data from Facebook, except for what you want to keep.
+            </p>
+        </div>
+
+        <XLastImportOrBuildComponent :account-i-d="model.account.id" :show-button="true" :show-no-data-warning="true"
+            :button-text="'Build Your Local Database'" :button-state="State.WizardDatabase"
+            @set-state="emit('setState', $event)" />
+
+        <form @submit.prevent>
+            <!-- deletePosts -->
+            <div class="mb-3">
+                <div class="d-flex align-items-center justify-content-between">
+                    <div class="form-check">
+                        <input id="deletePosts" v-model="deletePosts" type="checkbox" class="form-check-input"
+                            :disabled="!hasSomeData">
+                        <label class="form-check-label mr-1 text-nowrap" for="deleteTweets">
+                            Delete my posts
+                        </label>
+                        <span class="ms-2 text-muted">(recommended)</span>
+                        <button class="btn btn-sm btn-link" @click="deletePostsShowMoreClicked">
+                            {{ deletePostsShowMoreButtonText }}
+                        </button>
+                    </div>
+                </div>
+                <div v-if="deletePostsShowMore" class="indent">
+                    <div class="d-flex align-items-center justify-content-between">
+                        <div class="d-flex align-items-center flex-nowrap">
+                            <div class="form-check">
+                                <input id="deletePostsDaysOldEnabled" v-model="deletePostsDaysOldEnabled"
+                                    type="checkbox" class="form-check-input" :disabled="!deletePosts || !hasSomeData">
+                                <label class="form-check-label mr-1 text-nowrap" for="deletePostsDaysOldEnabled">
+                                    older than
+                                </label>
+                            </div>
+                            <div class="d-flex align-items-center">
+                                <label class="form-check-label mr-1 sr-only" for="deletePostsDaysOld">
+                                    days
+                                </label>
+                                <div class="input-group flex-nowrap">
+                                    <input id="deletePostsDaysOld" v-model="deletePostsDaysOld" type="text"
+                                        class="form-control form-short small"
+                                        :disabled="!deletePosts || !deletePostsDaysOldEnabled || !hasSomeData">
+                                    <div class="input-group-append">
+                                        <span class="input-group-text small">days</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <span v-if="!userAuthenticated || !userPremium"
+                            class="premium badge badge-primary">Premium</span>
+                    </div>
+                </div>
+            </div>
+
+            <!--     -->
+            <div class="mb-3">
+                <div class="d-flex align-items-center justify-content-between">
+                    <div class="form-check">
+                        <input id="deleteReposts" v-model="deleteReposts" type="checkbox" class="form-check-input"
+                            :disabled="!hasSomeData">
+                        <label class="form-check-label mr-1 text-nowrap" for="deleteReposts">
+                            Delete my reposts
+                        </label>
+                        <span class="ms-2 text-muted">(recommended)</span>
+                        <button class="btn btn-sm btn-link" @click="deleteRepostsShowMoreClicked">
+                            {{ deleteRepostsShowMoreButtonText }}
+                        </button>
+                    </div>
+                </div>
+                <div v-if="deleteRepostsShowMore" class="indent">
+                    <div class="d-flex align-items-center justify-content-between">
+                        <div class="d-flex align-items-center flex-nowrap">
+                            <div class="form-check">
+                                <input id="deleteRepostsDaysOldEnabled" v-model="deleteRepostsDaysOldEnabled"
+                                    type="checkbox" class="form-check-input"
+                                    :disabled="!deleteReposts || !hasSomeData">
+                                <label class="form-check-label mr-1 text-nowrap" for="deleteRepostsDaysOldEnabled">
+                                    older than
+                                </label>
+                            </div>
+                            <div class="d-flex align-items-center">
+                                <label class="form-check-label mr-1 sr-only" for="deleteRepostsDaysOld">
+                                    days
+                                </label>
+                                <div class="input-group flex-nowrap">
+                                    <input id="deleteRepostsDaysOld" v-model="deleteRepostsDaysOld" type="text"
+                                        class="form-control form-short small"
+                                        :disabled="!deleteReposts || !deleteRepostsDaysOldEnabled">
+                                    <div class="input-group-append">
+                                        <span class="input-group-text small">days</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <span v-if="!userAuthenticated || !userPremium"
+                            class="premium badge badge-primary">Premium</span>
+                    </div>
+                </div>
+            </div>
+
+            <div class="buttons">
+                <button type="submit" class="btn btn-primary text-nowrap m-1"
+                    :disabled="(hasSomeData && !(deletePosts || deleteReposts))"
+                    @click="nextClicked">
+                    <i class="fa-solid fa-forward" />
+                    Continue to Review
+                </button>
+            </div>
+        </form>
+    </div>
+</template>
+
+<style scoped>
+.form-short {
+    width: 55px;
+}
+
+.small {
+    font-size: 0.9rem;
+}
+</style>

--- a/src/renderer/src/views/facebook/FacebookWizardImportPage.vue
+++ b/src/renderer/src/views/facebook/FacebookWizardImportPage.vue
@@ -85,8 +85,7 @@ const backClicked = async () => {
             </ul>
 
             <div class="buttons mb-4">
-                <button type="submit" class="btn btn-primary text-nowrap m-1" :disabled="!(
-                    model.account?.facebookAccount?.saveMyData)" @click="importClicked">
+                <button type="submit" class="btn btn-primary text-nowrap m-1" @click="importClicked">
                     <i class="fa-solid fa-file-import" />
                     I've Downloaded My Archive from Facebook
                 </button>

--- a/src/shared_types/account.ts
+++ b/src/shared_types/account.ts
@@ -86,6 +86,7 @@ export type FacebookAccount = {
     profileImageDataURI: string;
     saveMyData: boolean;
     deleteMyData: boolean;
+    archiveMyData: boolean;
     savePosts: boolean;
     savePostsHTML: boolean;
     deletePosts: boolean;
@@ -93,4 +94,7 @@ export type FacebookAccount = {
     deletePostsDaysOld: number;
     deletePostsReactsThresholdEnabled: boolean;
     deletePostsReactsThreshold: number;
+    deleteReposts: boolean;
+    deleteRepostsDaysOldEnabled: boolean;
+    deleteRepostsDaysOld: number;
 }

--- a/src/shared_types/facebook.ts
+++ b/src/shared_types/facebook.ts
@@ -29,3 +29,21 @@ export type FacebookImportArchiveResponse = {
     importCount: number;
     skipCount: number;
 }
+
+
+// TODO: Add additional fields here
+export type FacebookDatabaseStats = {
+    postsSaved: number;
+    postsDeleted: number;
+    repostsSaved: number;
+    repostsDeleted: number;
+}
+
+export function emptyFacebookDatabaseStats(): FacebookDatabaseStats {
+    return {
+        postsSaved: 0,
+        postsDeleted: 0,
+        repostsSaved: 0,
+        repostsDeleted: 0,
+    }
+}


### PR DESCRIPTION
Closes #465

This implements a few more of the required pages for Facebook after importing your Meta export:


<img width="737" alt="Screenshot 2025-03-23 at 3 59 07 PM" src="https://github.com/user-attachments/assets/60e4acb7-de8c-4c39-b40a-bf7432bd916e" />
<img width="687" alt="Screenshot 2025-03-23 at 3 58 57 PM" src="https://github.com/user-attachments/assets/4b8b1056-de46-4576-814f-ba294cb95e17" />

