### PR TITLE
If loading a URL fails, wait 1 second before retrying loading the URL

### DIFF
--- a/src/renderer/src/view_models/BaseViewModel.ts
+++ b/src/renderer/src/view_models/BaseViewModel.ts
@@ -483,6 +483,9 @@ export class BaseViewModel {
                                 this.sleep(1000);
                             }
                         }
+                    } else {
+                        // Wait 1 second before retrying
+                        this.sleep(1000);
                     }
                 }
             }


### PR DESCRIPTION
Hopefully fixes #466, but it's hard to tell because it's hard to reliably reproduce.

I believe the GUEST_VIEW_MANAGER_CALL error happens because we're trying to load a URL in the `<webview>` before something is fully initialized (either the webview itself, the MITM CA, or something).

Our `BaseViewModel.loadURL` function tries 3 times before erroring it, but it doesn't wait between retries. This sleeps 1 second between retries, which hopefully will give the webview or MITM proxy, or whatever, enough time to finish initializing.

See https://github.com/lockdown-systems/cyd/issues/466#issuecomment-2770640629 for more details.