### PR TITLE
Handle change in X API responses

### DIFF
--- a/src/account_x/types.ts
+++ b/src/account_x/types.ts
@@ -333,7 +333,8 @@ export interface XAPIData {
         user: {
             result: {
                 __typename: string; // "User"
-                timeline_v2: XAPITimeline;
+                timeline_v2?: XAPITimeline;
+                timeline?: XAPITimeline;
             }
         }
     }
@@ -354,6 +355,10 @@ export function isXAPIError(body: any): body is XAPIData {
 }
 
 export function isXAPIData(body: any): body is XAPIData {
+    return !!(body.data && body.data.user && body.data.user.result && body.data.user.result.timeline);
+}
+
+export function isXAPIData_v2(body: any): body is XAPIData {
     return !!(body.data && body.data.user && body.data.user.result && body.data.user.result.timeline_v2);
 }
 

--- a/src/account_x/x_account_controller.ts
+++ b/src/account_x/x_account_controller.ts
@@ -89,6 +89,7 @@ import {
     isXAPIBookmarksData,
     isXAPIError,
     isXAPIData,
+    isXAPIData_v2,
 } from './types'
 import * as XArchiveTypes from '../../archive-static-sites/x-archive/src/types';
 
@@ -647,6 +648,8 @@ export class XAccountController {
             new Date(),
         ]);
 
+        log.debug("XAccountController.indexTweet: indexed tweet", this.account?.username, userLegacy, tweetLegacy);
+
         // Update progress
         if (tweetLegacy["favorited"]) {
             // console.log("DEBUG-### LIKE: ", tweetLegacy["id_str"], userLegacy["screen_name"], tweetLegacy["full_text"]);
@@ -703,12 +706,15 @@ export class XAccountController {
             if (isXAPIBookmarksData(body)) {
                 timeline = (body as XAPIBookmarksData).data.bookmark_timeline_v2;
             } else if (isXAPIData(body)) {
-                timeline = (body as XAPIData).data.user.result.timeline_v2;
+                timeline = (body as XAPIData).data.user.result.timeline as XAPITimeline;
+            } else if (isXAPIData_v2(body)) {
+                timeline = (body as XAPIData).data.user.result.timeline_v2 as XAPITimeline;
             } else if (isXAPIError(body)) {
                 log.error('XAccountController.indexParseTweetsResponseData: XAPIError', body);
                 this.mitmController.responseData[responseIndex].processed = true;
                 return false;
             } else {
+                log.error('XAccountController.indexParseTweetsResponseData: Invalid response data', responseData.body);
                 throw new Error('Invalid response data');
             }
 

--- a/testdata/XUserTweetsAndReplies_20250404.json
+++ b/testdata/XUserTweetsAndReplies_20250404.json
@@ -1,0 +1,6924 @@
+{
+    "data": {
+        "user": {
+            "result": {
+                "__typename": "User",
+                "timeline": {
+                    "timeline": {
+                        "instructions": [
+                            {
+                                "type": "TimelineClearCache"
+                            },
+                            {
+                                "type": "TimelineAddEntries",
+                                "entries": [
+                                    {
+                                        "entryId": "tweet-1889789128130125848",
+                                        "sortIndex": "1908263658341793792",
+                                        "content": {
+                                            "entryType": "TimelineTimelineItem",
+                                            "__typename": "TimelineTimelineItem",
+                                            "itemContent": {
+                                                "itemType": "TimelineTweet",
+                                                "__typename": "TimelineTweet",
+                                                "tweet_results": {
+                                                    "result": {
+                                                        "__typename": "Tweet",
+                                                        "rest_id": "1889789128130125848",
+                                                        "core": {
+                                                            "user_results": {
+                                                                "result": {
+                                                                    "__typename": "User",
+                                                                    "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                    "rest_id": "1769424777998180352",
+                                                                    "affiliates_highlighted_label": {},
+                                                                    "has_graduated_access": false,
+                                                                    "parody_commentary_fan_label": "None",
+                                                                    "is_blue_verified": false,
+                                                                    "profile_image_shape": "Circle",
+                                                                    "legacy": {
+                                                                        "following": false,
+                                                                        "can_dm": true,
+                                                                        "can_media_tag": true,
+                                                                        "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                        "default_profile": true,
+                                                                        "default_profile_image": false,
+                                                                        "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                        "entities": {
+                                                                            "description": {
+                                                                                "urls": []
+                                                                            }
+                                                                        },
+                                                                        "fast_followers_count": 0,
+                                                                        "favourites_count": 124,
+                                                                        "followers_count": 0,
+                                                                        "friends_count": 0,
+                                                                        "has_custom_timelines": false,
+                                                                        "is_translator": false,
+                                                                        "listed_count": 0,
+                                                                        "location": "",
+                                                                        "media_count": 0,
+                                                                        "name": "aurorabyte",
+                                                                        "needs_phone_verification": false,
+                                                                        "normal_followers_count": 0,
+                                                                        "pinned_tweet_ids_str": [],
+                                                                        "possibly_sensitive": false,
+                                                                        "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                        "profile_interstitial_type": "",
+                                                                        "screen_name": "aurorabyte79324",
+                                                                        "statuses_count": 355,
+                                                                        "translator_type": "none",
+                                                                        "verified": false,
+                                                                        "want_retweets": false,
+                                                                        "withheld_in_countries": []
+                                                                    },
+                                                                    "tipjar_settings": {}
+                                                                }
+                                                            }
+                                                        },
+                                                        "unmention_data": {},
+                                                        "edit_control": {
+                                                            "edit_tweet_ids": [
+                                                                "1889789128130125848"
+                                                            ],
+                                                            "editable_until_msecs": "1739399413000",
+                                                            "is_edit_eligible": true,
+                                                            "edits_remaining": "5"
+                                                        },
+                                                        "is_translatable": false,
+                                                        "views": {
+                                                            "count": "3",
+                                                            "state": "EnabledWithCount"
+                                                        },
+                                                        "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                        "grok_analysis_button": true,
+                                                        "legacy": {
+                                                            "bookmark_count": 0,
+                                                            "bookmarked": false,
+                                                            "created_at": "Wed Feb 12 21:30:13 +0000 2025",
+                                                            "conversation_id_str": "1889789128130125848",
+                                                            "display_text_range": [
+                                                                0,
+                                                                42
+                                                            ],
+                                                            "entities": {
+                                                                "hashtags": [],
+                                                                "symbols": [],
+                                                                "timestamps": [],
+                                                                "urls": [],
+                                                                "user_mentions": []
+                                                            },
+                                                            "favorite_count": 0,
+                                                            "favorited": false,
+                                                            "full_text": "Pixels at play, creating visual symphonies",
+                                                            "is_quote_status": false,
+                                                            "lang": "en",
+                                                            "quote_count": 0,
+                                                            "reply_count": 0,
+                                                            "retweet_count": 0,
+                                                            "retweeted": false,
+                                                            "user_id_str": "1769424777998180352",
+                                                            "id_str": "1889789128130125848"
+                                                        }
+                                                    }
+                                                },
+                                                "tweetDisplayType": "Tweet"
+                                            },
+                                            "clientEventInfo": {
+                                                "component": "tweet",
+                                                "element": "tweet",
+                                                "details": {
+                                                    "timelinesDetails": {
+                                                        "injectionType": "RankedOrganicTweet",
+                                                        "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "entryId": "tweet-1889783937247100932",
+                                        "sortIndex": "1908263658341793791",
+                                        "content": {
+                                            "entryType": "TimelineTimelineItem",
+                                            "__typename": "TimelineTimelineItem",
+                                            "itemContent": {
+                                                "itemType": "TimelineTweet",
+                                                "__typename": "TimelineTweet",
+                                                "tweet_results": {
+                                                    "result": {
+                                                        "__typename": "Tweet",
+                                                        "rest_id": "1889783937247100932",
+                                                        "core": {
+                                                            "user_results": {
+                                                                "result": {
+                                                                    "__typename": "User",
+                                                                    "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                    "rest_id": "1769424777998180352",
+                                                                    "affiliates_highlighted_label": {},
+                                                                    "has_graduated_access": false,
+                                                                    "parody_commentary_fan_label": "None",
+                                                                    "is_blue_verified": false,
+                                                                    "profile_image_shape": "Circle",
+                                                                    "legacy": {
+                                                                        "following": false,
+                                                                        "can_dm": true,
+                                                                        "can_media_tag": true,
+                                                                        "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                        "default_profile": true,
+                                                                        "default_profile_image": false,
+                                                                        "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                        "entities": {
+                                                                            "description": {
+                                                                                "urls": []
+                                                                            }
+                                                                        },
+                                                                        "fast_followers_count": 0,
+                                                                        "favourites_count": 124,
+                                                                        "followers_count": 0,
+                                                                        "friends_count": 0,
+                                                                        "has_custom_timelines": false,
+                                                                        "is_translator": false,
+                                                                        "listed_count": 0,
+                                                                        "location": "",
+                                                                        "media_count": 0,
+                                                                        "name": "aurorabyte",
+                                                                        "needs_phone_verification": false,
+                                                                        "normal_followers_count": 0,
+                                                                        "pinned_tweet_ids_str": [],
+                                                                        "possibly_sensitive": false,
+                                                                        "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                        "profile_interstitial_type": "",
+                                                                        "screen_name": "aurorabyte79324",
+                                                                        "statuses_count": 355,
+                                                                        "translator_type": "none",
+                                                                        "verified": false,
+                                                                        "want_retweets": false,
+                                                                        "withheld_in_countries": []
+                                                                    },
+                                                                    "tipjar_settings": {}
+                                                                }
+                                                            }
+                                                        },
+                                                        "unmention_data": {},
+                                                        "edit_control": {
+                                                            "edit_tweet_ids": [
+                                                                "1889783937247100932"
+                                                            ],
+                                                            "editable_until_msecs": "1739398175784",
+                                                            "is_edit_eligible": false,
+                                                            "edits_remaining": "5"
+                                                        },
+                                                        "is_translatable": false,
+                                                        "views": {
+                                                            "state": "Enabled"
+                                                        },
+                                                        "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                        "grok_analysis_button": true,
+                                                        "legacy": {
+                                                            "bookmark_count": 0,
+                                                            "bookmarked": false,
+                                                            "created_at": "Wed Feb 12 21:09:35 +0000 2025",
+                                                            "conversation_id_str": "1889783937247100932",
+                                                            "display_text_range": [
+                                                                0,
+                                                                140
+                                                            ],
+                                                            "entities": {
+                                                                "hashtags": [],
+                                                                "symbols": [],
+                                                                "timestamps": [],
+                                                                "urls": [],
+                                                                "user_mentions": [
+                                                                    {
+                                                                        "id_str": "2898790691",
+                                                                        "name": "Brian Allen",
+                                                                        "screen_name": "allenanalysis",
+                                                                        "indices": [
+                                                                            3,
+                                                                            17
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "favorite_count": 0,
+                                                            "favorited": false,
+                                                            "full_text": "RT @allenanalysis: \uD83D\uDEA8 REP. MAXINE WATERS: “Elon Musk, where are you? Bring your ass over here. We’re not afraid of you. We know you’re the c…",
+                                                            "is_quote_status": false,
+                                                            "lang": "en",
+                                                            "quote_count": 0,
+                                                            "reply_count": 0,
+                                                            "retweet_count": 4356,
+                                                            "retweeted": true,
+                                                            "user_id_str": "1769424777998180352",
+                                                            "id_str": "1889783937247100932",
+                                                            "retweeted_status_result": {
+                                                                "result": {
+                                                                    "__typename": "Tweet",
+                                                                    "rest_id": "1889096544961642508",
+                                                                    "core": {
+                                                                        "user_results": {
+                                                                            "result": {
+                                                                                "__typename": "User",
+                                                                                "id": "VXNlcjoyODk4NzkwNjkx",
+                                                                                "rest_id": "2898790691",
+                                                                                "affiliates_highlighted_label": {},
+                                                                                "has_graduated_access": true,
+                                                                                "parody_commentary_fan_label": "None",
+                                                                                "is_blue_verified": true,
+                                                                                "profile_image_shape": "Circle",
+                                                                                "legacy": {
+                                                                                    "following": false,
+                                                                                    "can_dm": true,
+                                                                                    "can_media_tag": false,
+                                                                                    "created_at": "Sun Nov 30 05:59:40 +0000 2014",
+                                                                                    "default_profile": true,
+                                                                                    "default_profile_image": false,
+                                                                                    "description": "Swinging a sledgehammer at the status quo. If it needs to be said, I’m saying it. Subscribe for less than a cup of coffee. Host of @theallenpod \uD83C\uDDFA\uD83C\uDDF8\uD83C\uDDEF\uD83C\uDDF2",
+                                                                                    "entities": {
+                                                                                        "description": {
+                                                                                            "urls": []
+                                                                                        }
+                                                                                    },
+                                                                                    "fast_followers_count": 0,
+                                                                                    "favourites_count": 23049,
+                                                                                    "followers_count": 137832,
+                                                                                    "friends_count": 173,
+                                                                                    "has_custom_timelines": true,
+                                                                                    "is_translator": false,
+                                                                                    "listed_count": 818,
+                                                                                    "location": "NYC",
+                                                                                    "media_count": 4637,
+                                                                                    "name": "Brian Allen",
+                                                                                    "normal_followers_count": 137832,
+                                                                                    "pinned_tweet_ids_str": [
+                                                                                        "1859266658323349691"
+                                                                                    ],
+                                                                                    "possibly_sensitive": false,
+                                                                                    "profile_banner_url": "https://pbs.twimg.com/profile_banners/2898790691/1743651746",
+                                                                                    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1757514152057221120/xQ42Ba_T_normal.jpg",
+                                                                                    "profile_interstitial_type": "",
+                                                                                    "screen_name": "allenanalysis",
+                                                                                    "statuses_count": 28195,
+                                                                                    "translator_type": "none",
+                                                                                    "verified": false,
+                                                                                    "want_retweets": false,
+                                                                                    "withheld_in_countries": []
+                                                                                },
+                                                                                "professional": {
+                                                                                    "rest_id": "1480783137806376961",
+                                                                                    "professional_type": "Business",
+                                                                                    "category": [
+                                                                                        {
+                                                                                            "id": 933,
+                                                                                            "name": "Media Personality",
+                                                                                            "icon_name": "IconBriefcaseStroke"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "tipjar_settings": {
+                                                                                    "is_enabled": false,
+                                                                                    "cash_app_handle": "brianallen98",
+                                                                                    "venmo_handle": "brianlimefundingllc"
+                                                                                },
+                                                                                "super_follow_eligible": true
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "unmention_data": {},
+                                                                    "edit_control": {
+                                                                        "edit_tweet_ids": [
+                                                                            "1889096544961642508"
+                                                                        ],
+                                                                        "editable_until_msecs": "1739234288000",
+                                                                        "is_edit_eligible": true,
+                                                                        "edits_remaining": "5"
+                                                                    },
+                                                                    "is_translatable": false,
+                                                                    "views": {
+                                                                        "count": "721551",
+                                                                        "state": "EnabledWithCount"
+                                                                    },
+                                                                    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                                                                    "note_tweet": {
+                                                                        "is_expandable": true,
+                                                                        "note_tweet_results": {
+                                                                            "result": {
+                                                                                "id": "Tm90ZVR3ZWV0OjE4ODkwOTY1NDQ4NjUwOTE1ODQ=",
+                                                                                "text": "\uD83D\uDEA8 REP. MAXINE WATERS: “Elon Musk, where are you? Bring your ass over here. We’re not afraid of you. We know you’re the co-president now… he’s a thief. He’s a gangster.”\n\nWaters just called Musk out to his face—no sugarcoating, no tech-bro worship, just straight-up fire. \n\nShe sees what’s happening: Musk isn’t just playing CEO, he’s running a shadow government with Trump, looting power like it’s one of his rigged stock schemes.",
+                                                                                "entity_set": {
+                                                                                    "hashtags": [],
+                                                                                    "symbols": [],
+                                                                                    "timestamps": [],
+                                                                                    "urls": [],
+                                                                                    "user_mentions": []
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "grok_analysis_button": true,
+                                                                    "legacy": {
+                                                                        "bookmark_count": 611,
+                                                                        "bookmarked": false,
+                                                                        "created_at": "Mon Feb 10 23:38:08 +0000 2025",
+                                                                        "conversation_id_str": "1889096544961642508",
+                                                                        "display_text_range": [
+                                                                            0,
+                                                                            276
+                                                                        ],
+                                                                        "entities": {
+                                                                            "hashtags": [],
+                                                                            "media": [
+                                                                                {
+                                                                                    "display_url": "pic.x.com/6fEJ6LQYTH",
+                                                                                    "expanded_url": "https://x.com/allenanalysis/status/1889096544961642508/video/1",
+                                                                                    "id_str": "1889096381484105728",
+                                                                                    "indices": [
+                                                                                        277,
+                                                                                        300
+                                                                                    ],
+                                                                                    "media_key": "13_1889096381484105728",
+                                                                                    "media_url_https": "https://pbs.twimg.com/amplify_video_thumb/1889096381484105728/img/8EHOpcb4Elrrc1St.jpg",
+                                                                                    "type": "video",
+                                                                                    "url": "https://t.co/6fEJ6LQYTH",
+                                                                                    "additional_media_info": {
+                                                                                        "monetizable": false
+                                                                                    },
+                                                                                    "ext_media_availability": {
+                                                                                        "status": "Available"
+                                                                                    },
+                                                                                    "sizes": {
+                                                                                        "large": {
+                                                                                            "h": 720,
+                                                                                            "w": 1280,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "medium": {
+                                                                                            "h": 675,
+                                                                                            "w": 1200,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "small": {
+                                                                                            "h": 383,
+                                                                                            "w": 680,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "thumb": {
+                                                                                            "h": 150,
+                                                                                            "w": 150,
+                                                                                            "resize": "crop"
+                                                                                        }
+                                                                                    },
+                                                                                    "original_info": {
+                                                                                        "height": 720,
+                                                                                        "width": 1280,
+                                                                                        "focus_rects": []
+                                                                                    },
+                                                                                    "allow_download_status": {
+                                                                                        "allow_download": true
+                                                                                    },
+                                                                                    "video_info": {
+                                                                                        "aspect_ratio": [
+                                                                                            16,
+                                                                                            9
+                                                                                        ],
+                                                                                        "duration_millis": 84008,
+                                                                                        "variants": [
+                                                                                            {
+                                                                                                "content_type": "application/x-mpegURL",
+                                                                                                "url": "https://video.twimg.com/amplify_video/1889096381484105728/pl/ZY6Ar7T2xw-iRbke.m3u8?tag=16&v=3d8"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 288000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/amplify_video/1889096381484105728/vid/avc1/480x270/E43_0vktq9G1CaDA.mp4?tag=16"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 832000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/amplify_video/1889096381484105728/vid/avc1/640x360/4aFRhWEQmHy-pfG-.mp4?tag=16"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 2176000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/amplify_video/1889096381484105728/vid/avc1/1280x720/ymdvYz3MatIjI-Tc.mp4?tag=16"
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    "media_results": {
+                                                                                        "result": {
+                                                                                            "media_key": "13_1889096381484105728"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            ],
+                                                                            "symbols": [],
+                                                                            "timestamps": [],
+                                                                            "urls": [],
+                                                                            "user_mentions": []
+                                                                        },
+                                                                        "extended_entities": {
+                                                                            "media": [
+                                                                                {
+                                                                                    "display_url": "pic.x.com/6fEJ6LQYTH",
+                                                                                    "expanded_url": "https://x.com/allenanalysis/status/1889096544961642508/video/1",
+                                                                                    "id_str": "1889096381484105728",
+                                                                                    "indices": [
+                                                                                        277,
+                                                                                        300
+                                                                                    ],
+                                                                                    "media_key": "13_1889096381484105728",
+                                                                                    "media_url_https": "https://pbs.twimg.com/amplify_video_thumb/1889096381484105728/img/8EHOpcb4Elrrc1St.jpg",
+                                                                                    "type": "video",
+                                                                                    "url": "https://t.co/6fEJ6LQYTH",
+                                                                                    "additional_media_info": {
+                                                                                        "monetizable": false
+                                                                                    },
+                                                                                    "ext_media_availability": {
+                                                                                        "status": "Available"
+                                                                                    },
+                                                                                    "sizes": {
+                                                                                        "large": {
+                                                                                            "h": 720,
+                                                                                            "w": 1280,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "medium": {
+                                                                                            "h": 675,
+                                                                                            "w": 1200,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "small": {
+                                                                                            "h": 383,
+                                                                                            "w": 680,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "thumb": {
+                                                                                            "h": 150,
+                                                                                            "w": 150,
+                                                                                            "resize": "crop"
+                                                                                        }
+                                                                                    },
+                                                                                    "original_info": {
+                                                                                        "height": 720,
+                                                                                        "width": 1280,
+                                                                                        "focus_rects": []
+                                                                                    },
+                                                                                    "allow_download_status": {
+                                                                                        "allow_download": true
+                                                                                    },
+                                                                                    "video_info": {
+                                                                                        "aspect_ratio": [
+                                                                                            16,
+                                                                                            9
+                                                                                        ],
+                                                                                        "duration_millis": 84008,
+                                                                                        "variants": [
+                                                                                            {
+                                                                                                "content_type": "application/x-mpegURL",
+                                                                                                "url": "https://video.twimg.com/amplify_video/1889096381484105728/pl/ZY6Ar7T2xw-iRbke.m3u8?tag=16&v=3d8"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 288000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/amplify_video/1889096381484105728/vid/avc1/480x270/E43_0vktq9G1CaDA.mp4?tag=16"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 832000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/amplify_video/1889096381484105728/vid/avc1/640x360/4aFRhWEQmHy-pfG-.mp4?tag=16"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 2176000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/amplify_video/1889096381484105728/vid/avc1/1280x720/ymdvYz3MatIjI-Tc.mp4?tag=16"
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    "media_results": {
+                                                                                        "result": {
+                                                                                            "media_key": "13_1889096381484105728"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "favorite_count": 16781,
+                                                                        "favorited": false,
+                                                                        "full_text": "\uD83D\uDEA8 REP. MAXINE WATERS: “Elon Musk, where are you? Bring your ass over here. We’re not afraid of you. We know you’re the co-president now… he’s a thief. He’s a gangster.”\n\nWaters just called Musk out to his face—no sugarcoating, no tech-bro worship, just straight-up fire. \n\nShe https://t.co/6fEJ6LQYTH",
+                                                                        "is_quote_status": false,
+                                                                        "lang": "en",
+                                                                        "possibly_sensitive": false,
+                                                                        "possibly_sensitive_editable": true,
+                                                                        "quote_count": 281,
+                                                                        "reply_count": 5387,
+                                                                        "retweet_count": 4356,
+                                                                        "retweeted": true,
+                                                                        "user_id_str": "2898790691",
+                                                                        "id_str": "1889096544961642508"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "tweetDisplayType": "Tweet"
+                                            },
+                                            "clientEventInfo": {
+                                                "component": "tweet",
+                                                "element": "tweet",
+                                                "details": {
+                                                    "timelinesDetails": {
+                                                        "injectionType": "RankedOrganicTweet",
+                                                        "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "entryId": "tweet-1889781338255061142",
+                                        "sortIndex": "1908263658341793790",
+                                        "content": {
+                                            "entryType": "TimelineTimelineItem",
+                                            "__typename": "TimelineTimelineItem",
+                                            "itemContent": {
+                                                "itemType": "TimelineTweet",
+                                                "__typename": "TimelineTweet",
+                                                "tweet_results": {
+                                                    "result": {
+                                                        "__typename": "Tweet",
+                                                        "rest_id": "1889781338255061142",
+                                                        "core": {
+                                                            "user_results": {
+                                                                "result": {
+                                                                    "__typename": "User",
+                                                                    "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                    "rest_id": "1769424777998180352",
+                                                                    "affiliates_highlighted_label": {},
+                                                                    "has_graduated_access": false,
+                                                                    "parody_commentary_fan_label": "None",
+                                                                    "is_blue_verified": false,
+                                                                    "profile_image_shape": "Circle",
+                                                                    "legacy": {
+                                                                        "following": false,
+                                                                        "can_dm": true,
+                                                                        "can_media_tag": true,
+                                                                        "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                        "default_profile": true,
+                                                                        "default_profile_image": false,
+                                                                        "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                        "entities": {
+                                                                            "description": {
+                                                                                "urls": []
+                                                                            }
+                                                                        },
+                                                                        "fast_followers_count": 0,
+                                                                        "favourites_count": 124,
+                                                                        "followers_count": 0,
+                                                                        "friends_count": 0,
+                                                                        "has_custom_timelines": false,
+                                                                        "is_translator": false,
+                                                                        "listed_count": 0,
+                                                                        "location": "",
+                                                                        "media_count": 0,
+                                                                        "name": "aurorabyte",
+                                                                        "needs_phone_verification": false,
+                                                                        "normal_followers_count": 0,
+                                                                        "pinned_tweet_ids_str": [],
+                                                                        "possibly_sensitive": false,
+                                                                        "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                        "profile_interstitial_type": "",
+                                                                        "screen_name": "aurorabyte79324",
+                                                                        "statuses_count": 355,
+                                                                        "translator_type": "none",
+                                                                        "verified": false,
+                                                                        "want_retweets": false,
+                                                                        "withheld_in_countries": []
+                                                                    },
+                                                                    "tipjar_settings": {}
+                                                                }
+                                                            }
+                                                        },
+                                                        "unmention_data": {},
+                                                        "edit_control": {
+                                                            "edit_tweet_ids": [
+                                                                "1889781338255061142"
+                                                            ],
+                                                            "editable_until_msecs": "1739397556136",
+                                                            "is_edit_eligible": false,
+                                                            "edits_remaining": "5"
+                                                        },
+                                                        "is_translatable": false,
+                                                        "views": {
+                                                            "state": "Enabled"
+                                                        },
+                                                        "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                        "grok_analysis_button": true,
+                                                        "legacy": {
+                                                            "bookmark_count": 0,
+                                                            "bookmarked": false,
+                                                            "created_at": "Wed Feb 12 20:59:16 +0000 2025",
+                                                            "conversation_id_str": "1889781338255061142",
+                                                            "display_text_range": [
+                                                                0,
+                                                                118
+                                                            ],
+                                                            "entities": {
+                                                                "hashtags": [],
+                                                                "media": [
+                                                                    {
+                                                                        "display_url": "pic.x.com/US8rriz3QX",
+                                                                        "expanded_url": "https://x.com/SenAdamSchiff/status/1889129755133276184/video/1",
+                                                                        "id_str": "1889129511532281857",
+                                                                        "indices": [
+                                                                            95,
+                                                                            118
+                                                                        ],
+                                                                        "media_key": "13_1889129511532281857",
+                                                                        "media_url_https": "https://pbs.twimg.com/amplify_video_thumb/1889129511532281857/img/E3PEWO_r4xYYNjLZ.jpg",
+                                                                        "source_status_id_str": "1889129755133276184",
+                                                                        "source_user_id_str": "29501253",
+                                                                        "type": "video",
+                                                                        "url": "https://t.co/US8rriz3QX",
+                                                                        "additional_media_info": {
+                                                                            "monetizable": false,
+                                                                            "source_user": {
+                                                                                "user_results": {
+                                                                                    "result": {
+                                                                                        "__typename": "User",
+                                                                                        "id": "VXNlcjoyOTUwMTI1Mw==",
+                                                                                        "rest_id": "29501253",
+                                                                                        "affiliates_highlighted_label": {
+                                                                                            "label": {
+                                                                                                "url": {
+                                                                                                    "url": "https://twitter.com/SenateDems",
+                                                                                                    "urlType": "DeepLink"
+                                                                                                },
+                                                                                                "badge": {
+                                                                                                    "url": "https://pbs.twimg.com/profile_images/1518618855458971649/EAp2b8sB_bigger.jpg"
+                                                                                                },
+                                                                                                "description": "Senate Democrats",
+                                                                                                "userLabelType": "BusinessLabel",
+                                                                                                "userLabelDisplayType": "Badge"
+                                                                                            }
+                                                                                        },
+                                                                                        "has_graduated_access": true,
+                                                                                        "parody_commentary_fan_label": "None",
+                                                                                        "is_blue_verified": true,
+                                                                                        "profile_image_shape": "Circle",
+                                                                                        "legacy": {
+                                                                                            "following": false,
+                                                                                            "can_dm": false,
+                                                                                            "can_media_tag": false,
+                                                                                            "created_at": "Tue Apr 07 17:54:35 +0000 2009",
+                                                                                            "default_profile": false,
+                                                                                            "default_profile_image": false,
+                                                                                            "description": "Husband. Father. U.S. Senator for California. Fighting for an economy that works for everyone and for our democracy.",
+                                                                                            "entities": {
+                                                                                                "description": {
+                                                                                                    "urls": []
+                                                                                                },
+                                                                                                "url": {
+                                                                                                    "urls": [
+                                                                                                        {
+                                                                                                            "display_url": "schiff.senate.gov/wildfire-resou…",
+                                                                                                            "expanded_url": "https://www.schiff.senate.gov/wildfire-resources/",
+                                                                                                            "url": "https://t.co/BFs4R5T1PA",
+                                                                                                            "indices": [
+                                                                                                                0,
+                                                                                                                23
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            },
+                                                                                            "fast_followers_count": 0,
+                                                                                            "favourites_count": 262,
+                                                                                            "followers_count": 3365006,
+                                                                                            "friends_count": 897,
+                                                                                            "has_custom_timelines": true,
+                                                                                            "is_translator": false,
+                                                                                            "listed_count": 13512,
+                                                                                            "location": "Burbank, CA",
+                                                                                            "media_count": 1837,
+                                                                                            "name": "Adam Schiff",
+                                                                                            "normal_followers_count": 3365006,
+                                                                                            "pinned_tweet_ids_str": [],
+                                                                                            "possibly_sensitive": false,
+                                                                                            "profile_banner_url": "https://pbs.twimg.com/profile_banners/29501253/1605113309",
+                                                                                            "profile_image_url_https": "https://pbs.twimg.com/profile_images/1268175179626303497/-DNpPNUm_normal.jpg",
+                                                                                            "profile_interstitial_type": "",
+                                                                                            "screen_name": "SenAdamSchiff",
+                                                                                            "statuses_count": 8364,
+                                                                                            "translator_type": "none",
+                                                                                            "url": "https://t.co/BFs4R5T1PA",
+                                                                                            "verified": false,
+                                                                                            "verified_type": "Government",
+                                                                                            "want_retweets": false,
+                                                                                            "withheld_in_countries": []
+                                                                                        },
+                                                                                        "tipjar_settings": {}
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "ext_media_availability": {
+                                                                            "status": "Available"
+                                                                        },
+                                                                        "sizes": {
+                                                                            "large": {
+                                                                                "h": 1080,
+                                                                                "w": 1920,
+                                                                                "resize": "fit"
+                                                                            },
+                                                                            "medium": {
+                                                                                "h": 675,
+                                                                                "w": 1200,
+                                                                                "resize": "fit"
+                                                                            },
+                                                                            "small": {
+                                                                                "h": 383,
+                                                                                "w": 680,
+                                                                                "resize": "fit"
+                                                                            },
+                                                                            "thumb": {
+                                                                                "h": 150,
+                                                                                "w": 150,
+                                                                                "resize": "crop"
+                                                                            }
+                                                                        },
+                                                                        "original_info": {
+                                                                            "height": 1080,
+                                                                            "width": 1920,
+                                                                            "focus_rects": []
+                                                                        },
+                                                                        "video_info": {
+                                                                            "aspect_ratio": [
+                                                                                16,
+                                                                                9
+                                                                            ],
+                                                                            "duration_millis": 76309,
+                                                                            "variants": [
+                                                                                {
+                                                                                    "content_type": "application/x-mpegURL",
+                                                                                    "url": "https://video.twimg.com/amplify_video/1889129511532281857/pl/3D5ogCWhXOC0Xw7I.m3u8?tag=16&v=d2a"
+                                                                                },
+                                                                                {
+                                                                                    "bitrate": 288000,
+                                                                                    "content_type": "video/mp4",
+                                                                                    "url": "https://video.twimg.com/amplify_video/1889129511532281857/vid/avc1/480x270/-AcPeWgwc36_BP_V.mp4?tag=16"
+                                                                                },
+                                                                                {
+                                                                                    "bitrate": 832000,
+                                                                                    "content_type": "video/mp4",
+                                                                                    "url": "https://video.twimg.com/amplify_video/1889129511532281857/vid/avc1/640x360/Emq8qgaxvTe0biIW.mp4?tag=16"
+                                                                                },
+                                                                                {
+                                                                                    "bitrate": 2176000,
+                                                                                    "content_type": "video/mp4",
+                                                                                    "url": "https://video.twimg.com/amplify_video/1889129511532281857/vid/avc1/1280x720/DVvwo_2mWn-bKAGb.mp4?tag=16"
+                                                                                },
+                                                                                {
+                                                                                    "bitrate": 10368000,
+                                                                                    "content_type": "video/mp4",
+                                                                                    "url": "https://video.twimg.com/amplify_video/1889129511532281857/vid/avc1/1920x1080/bucVFAZ-YwmMyy1h.mp4?tag=16"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "media_results": {
+                                                                            "result": {
+                                                                                "media_key": "13_1889129511532281857"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ],
+                                                                "symbols": [],
+                                                                "timestamps": [],
+                                                                "urls": [],
+                                                                "user_mentions": [
+                                                                    {
+                                                                        "id_str": "29501253",
+                                                                        "name": "Adam Schiff",
+                                                                        "screen_name": "SenAdamSchiff",
+                                                                        "indices": [
+                                                                            3,
+                                                                            17
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "extended_entities": {
+                                                                "media": [
+                                                                    {
+                                                                        "display_url": "pic.x.com/US8rriz3QX",
+                                                                        "expanded_url": "https://x.com/SenAdamSchiff/status/1889129755133276184/video/1",
+                                                                        "id_str": "1889129511532281857",
+                                                                        "indices": [
+                                                                            95,
+                                                                            118
+                                                                        ],
+                                                                        "media_key": "13_1889129511532281857",
+                                                                        "media_url_https": "https://pbs.twimg.com/amplify_video_thumb/1889129511532281857/img/E3PEWO_r4xYYNjLZ.jpg",
+                                                                        "source_status_id_str": "1889129755133276184",
+                                                                        "source_user_id_str": "29501253",
+                                                                        "type": "video",
+                                                                        "url": "https://t.co/US8rriz3QX",
+                                                                        "additional_media_info": {
+                                                                            "monetizable": false,
+                                                                            "source_user": {
+                                                                                "user_results": {
+                                                                                    "result": {
+                                                                                        "__typename": "User",
+                                                                                        "id": "VXNlcjoyOTUwMTI1Mw==",
+                                                                                        "rest_id": "29501253",
+                                                                                        "affiliates_highlighted_label": {
+                                                                                            "label": {
+                                                                                                "url": {
+                                                                                                    "url": "https://twitter.com/SenateDems",
+                                                                                                    "urlType": "DeepLink"
+                                                                                                },
+                                                                                                "badge": {
+                                                                                                    "url": "https://pbs.twimg.com/profile_images/1518618855458971649/EAp2b8sB_bigger.jpg"
+                                                                                                },
+                                                                                                "description": "Senate Democrats",
+                                                                                                "userLabelType": "BusinessLabel",
+                                                                                                "userLabelDisplayType": "Badge"
+                                                                                            }
+                                                                                        },
+                                                                                        "has_graduated_access": true,
+                                                                                        "parody_commentary_fan_label": "None",
+                                                                                        "is_blue_verified": true,
+                                                                                        "profile_image_shape": "Circle",
+                                                                                        "legacy": {
+                                                                                            "following": false,
+                                                                                            "can_dm": false,
+                                                                                            "can_media_tag": false,
+                                                                                            "created_at": "Tue Apr 07 17:54:35 +0000 2009",
+                                                                                            "default_profile": false,
+                                                                                            "default_profile_image": false,
+                                                                                            "description": "Husband. Father. U.S. Senator for California. Fighting for an economy that works for everyone and for our democracy.",
+                                                                                            "entities": {
+                                                                                                "description": {
+                                                                                                    "urls": []
+                                                                                                },
+                                                                                                "url": {
+                                                                                                    "urls": [
+                                                                                                        {
+                                                                                                            "display_url": "schiff.senate.gov/wildfire-resou…",
+                                                                                                            "expanded_url": "https://www.schiff.senate.gov/wildfire-resources/",
+                                                                                                            "url": "https://t.co/BFs4R5T1PA",
+                                                                                                            "indices": [
+                                                                                                                0,
+                                                                                                                23
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            },
+                                                                                            "fast_followers_count": 0,
+                                                                                            "favourites_count": 262,
+                                                                                            "followers_count": 3365006,
+                                                                                            "friends_count": 897,
+                                                                                            "has_custom_timelines": true,
+                                                                                            "is_translator": false,
+                                                                                            "listed_count": 13512,
+                                                                                            "location": "Burbank, CA",
+                                                                                            "media_count": 1837,
+                                                                                            "name": "Adam Schiff",
+                                                                                            "normal_followers_count": 3365006,
+                                                                                            "pinned_tweet_ids_str": [],
+                                                                                            "possibly_sensitive": false,
+                                                                                            "profile_banner_url": "https://pbs.twimg.com/profile_banners/29501253/1605113309",
+                                                                                            "profile_image_url_https": "https://pbs.twimg.com/profile_images/1268175179626303497/-DNpPNUm_normal.jpg",
+                                                                                            "profile_interstitial_type": "",
+                                                                                            "screen_name": "SenAdamSchiff",
+                                                                                            "statuses_count": 8364,
+                                                                                            "translator_type": "none",
+                                                                                            "url": "https://t.co/BFs4R5T1PA",
+                                                                                            "verified": false,
+                                                                                            "verified_type": "Government",
+                                                                                            "want_retweets": false,
+                                                                                            "withheld_in_countries": []
+                                                                                        },
+                                                                                        "tipjar_settings": {}
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "ext_media_availability": {
+                                                                            "status": "Available"
+                                                                        },
+                                                                        "sizes": {
+                                                                            "large": {
+                                                                                "h": 1080,
+                                                                                "w": 1920,
+                                                                                "resize": "fit"
+                                                                            },
+                                                                            "medium": {
+                                                                                "h": 675,
+                                                                                "w": 1200,
+                                                                                "resize": "fit"
+                                                                            },
+                                                                            "small": {
+                                                                                "h": 383,
+                                                                                "w": 680,
+                                                                                "resize": "fit"
+                                                                            },
+                                                                            "thumb": {
+                                                                                "h": 150,
+                                                                                "w": 150,
+                                                                                "resize": "crop"
+                                                                            }
+                                                                        },
+                                                                        "original_info": {
+                                                                            "height": 1080,
+                                                                            "width": 1920,
+                                                                            "focus_rects": []
+                                                                        },
+                                                                        "video_info": {
+                                                                            "aspect_ratio": [
+                                                                                16,
+                                                                                9
+                                                                            ],
+                                                                            "duration_millis": 76309,
+                                                                            "variants": [
+                                                                                {
+                                                                                    "content_type": "application/x-mpegURL",
+                                                                                    "url": "https://video.twimg.com/amplify_video/1889129511532281857/pl/3D5ogCWhXOC0Xw7I.m3u8?tag=16&v=d2a"
+                                                                                },
+                                                                                {
+                                                                                    "bitrate": 288000,
+                                                                                    "content_type": "video/mp4",
+                                                                                    "url": "https://video.twimg.com/amplify_video/1889129511532281857/vid/avc1/480x270/-AcPeWgwc36_BP_V.mp4?tag=16"
+                                                                                },
+                                                                                {
+                                                                                    "bitrate": 832000,
+                                                                                    "content_type": "video/mp4",
+                                                                                    "url": "https://video.twimg.com/amplify_video/1889129511532281857/vid/avc1/640x360/Emq8qgaxvTe0biIW.mp4?tag=16"
+                                                                                },
+                                                                                {
+                                                                                    "bitrate": 2176000,
+                                                                                    "content_type": "video/mp4",
+                                                                                    "url": "https://video.twimg.com/amplify_video/1889129511532281857/vid/avc1/1280x720/DVvwo_2mWn-bKAGb.mp4?tag=16"
+                                                                                },
+                                                                                {
+                                                                                    "bitrate": 10368000,
+                                                                                    "content_type": "video/mp4",
+                                                                                    "url": "https://video.twimg.com/amplify_video/1889129511532281857/vid/avc1/1920x1080/bucVFAZ-YwmMyy1h.mp4?tag=16"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "media_results": {
+                                                                            "result": {
+                                                                                "media_key": "13_1889129511532281857"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "favorite_count": 0,
+                                                            "favorited": false,
+                                                            "full_text": "RT @SenAdamSchiff: To my Republican colleagues – where do you draw the line with Donald Trump? https://t.co/US8rriz3QX",
+                                                            "is_quote_status": false,
+                                                            "lang": "en",
+                                                            "possibly_sensitive": false,
+                                                            "possibly_sensitive_editable": true,
+                                                            "quote_count": 0,
+                                                            "reply_count": 0,
+                                                            "retweet_count": 2639,
+                                                            "retweeted": true,
+                                                            "user_id_str": "1769424777998180352",
+                                                            "id_str": "1889781338255061142",
+                                                            "retweeted_status_result": {
+                                                                "result": {
+                                                                    "__typename": "Tweet",
+                                                                    "rest_id": "1889129755133276184",
+                                                                    "core": {
+                                                                        "user_results": {
+                                                                            "result": {
+                                                                                "__typename": "User",
+                                                                                "id": "VXNlcjoyOTUwMTI1Mw==",
+                                                                                "rest_id": "29501253",
+                                                                                "affiliates_highlighted_label": {
+                                                                                    "label": {
+                                                                                        "url": {
+                                                                                            "url": "https://twitter.com/SenateDems",
+                                                                                            "urlType": "DeepLink"
+                                                                                        },
+                                                                                        "badge": {
+                                                                                            "url": "https://pbs.twimg.com/profile_images/1518618855458971649/EAp2b8sB_bigger.jpg"
+                                                                                        },
+                                                                                        "description": "Senate Democrats",
+                                                                                        "userLabelType": "BusinessLabel",
+                                                                                        "userLabelDisplayType": "Badge"
+                                                                                    }
+                                                                                },
+                                                                                "has_graduated_access": true,
+                                                                                "parody_commentary_fan_label": "None",
+                                                                                "is_blue_verified": true,
+                                                                                "profile_image_shape": "Circle",
+                                                                                "legacy": {
+                                                                                    "following": false,
+                                                                                    "can_dm": false,
+                                                                                    "can_media_tag": false,
+                                                                                    "created_at": "Tue Apr 07 17:54:35 +0000 2009",
+                                                                                    "default_profile": false,
+                                                                                    "default_profile_image": false,
+                                                                                    "description": "Husband. Father. U.S. Senator for California. Fighting for an economy that works for everyone and for our democracy.",
+                                                                                    "entities": {
+                                                                                        "description": {
+                                                                                            "urls": []
+                                                                                        },
+                                                                                        "url": {
+                                                                                            "urls": [
+                                                                                                {
+                                                                                                    "display_url": "schiff.senate.gov/wildfire-resou…",
+                                                                                                    "expanded_url": "https://www.schiff.senate.gov/wildfire-resources/",
+                                                                                                    "url": "https://t.co/BFs4R5T1PA",
+                                                                                                    "indices": [
+                                                                                                        0,
+                                                                                                        23
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "fast_followers_count": 0,
+                                                                                    "favourites_count": 262,
+                                                                                    "followers_count": 3365006,
+                                                                                    "friends_count": 897,
+                                                                                    "has_custom_timelines": true,
+                                                                                    "is_translator": false,
+                                                                                    "listed_count": 13512,
+                                                                                    "location": "Burbank, CA",
+                                                                                    "media_count": 1837,
+                                                                                    "name": "Adam Schiff",
+                                                                                    "normal_followers_count": 3365006,
+                                                                                    "pinned_tweet_ids_str": [],
+                                                                                    "possibly_sensitive": false,
+                                                                                    "profile_banner_url": "https://pbs.twimg.com/profile_banners/29501253/1605113309",
+                                                                                    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1268175179626303497/-DNpPNUm_normal.jpg",
+                                                                                    "profile_interstitial_type": "",
+                                                                                    "screen_name": "SenAdamSchiff",
+                                                                                    "statuses_count": 8364,
+                                                                                    "translator_type": "none",
+                                                                                    "url": "https://t.co/BFs4R5T1PA",
+                                                                                    "verified": false,
+                                                                                    "verified_type": "Government",
+                                                                                    "want_retweets": false,
+                                                                                    "withheld_in_countries": []
+                                                                                },
+                                                                                "tipjar_settings": {}
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "unmention_data": {},
+                                                                    "edit_control": {
+                                                                        "edit_tweet_ids": [
+                                                                            "1889129755133276184"
+                                                                        ],
+                                                                        "editable_until_msecs": "1739242206000",
+                                                                        "is_edit_eligible": true,
+                                                                        "edits_remaining": "5"
+                                                                    },
+                                                                    "is_translatable": false,
+                                                                    "views": {
+                                                                        "count": "411742",
+                                                                        "state": "EnabledWithCount"
+                                                                    },
+                                                                    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                                                                    "grok_analysis_button": true,
+                                                                    "legacy": {
+                                                                        "bookmark_count": 203,
+                                                                        "bookmarked": false,
+                                                                        "created_at": "Tue Feb 11 01:50:06 +0000 2025",
+                                                                        "conversation_id_str": "1889129755133276184",
+                                                                        "display_text_range": [
+                                                                            0,
+                                                                            75
+                                                                        ],
+                                                                        "entities": {
+                                                                            "hashtags": [],
+                                                                            "media": [
+                                                                                {
+                                                                                    "display_url": "pic.x.com/US8rriz3QX",
+                                                                                    "expanded_url": "https://x.com/SenAdamSchiff/status/1889129755133276184/video/1",
+                                                                                    "id_str": "1889129511532281857",
+                                                                                    "indices": [
+                                                                                        76,
+                                                                                        99
+                                                                                    ],
+                                                                                    "media_key": "13_1889129511532281857",
+                                                                                    "media_url_https": "https://pbs.twimg.com/amplify_video_thumb/1889129511532281857/img/E3PEWO_r4xYYNjLZ.jpg",
+                                                                                    "type": "video",
+                                                                                    "url": "https://t.co/US8rriz3QX",
+                                                                                    "additional_media_info": {
+                                                                                        "monetizable": false
+                                                                                    },
+                                                                                    "ext_media_availability": {
+                                                                                        "status": "Available"
+                                                                                    },
+                                                                                    "sizes": {
+                                                                                        "large": {
+                                                                                            "h": 1080,
+                                                                                            "w": 1920,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "medium": {
+                                                                                            "h": 675,
+                                                                                            "w": 1200,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "small": {
+                                                                                            "h": 383,
+                                                                                            "w": 680,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "thumb": {
+                                                                                            "h": 150,
+                                                                                            "w": 150,
+                                                                                            "resize": "crop"
+                                                                                        }
+                                                                                    },
+                                                                                    "original_info": {
+                                                                                        "height": 1080,
+                                                                                        "width": 1920,
+                                                                                        "focus_rects": []
+                                                                                    },
+                                                                                    "video_info": {
+                                                                                        "aspect_ratio": [
+                                                                                            16,
+                                                                                            9
+                                                                                        ],
+                                                                                        "duration_millis": 76309,
+                                                                                        "variants": [
+                                                                                            {
+                                                                                                "content_type": "application/x-mpegURL",
+                                                                                                "url": "https://video.twimg.com/amplify_video/1889129511532281857/pl/3D5ogCWhXOC0Xw7I.m3u8?tag=16&v=d2a"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 288000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/amplify_video/1889129511532281857/vid/avc1/480x270/-AcPeWgwc36_BP_V.mp4?tag=16"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 832000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/amplify_video/1889129511532281857/vid/avc1/640x360/Emq8qgaxvTe0biIW.mp4?tag=16"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 2176000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/amplify_video/1889129511532281857/vid/avc1/1280x720/DVvwo_2mWn-bKAGb.mp4?tag=16"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 10368000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/amplify_video/1889129511532281857/vid/avc1/1920x1080/bucVFAZ-YwmMyy1h.mp4?tag=16"
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    "media_results": {
+                                                                                        "result": {
+                                                                                            "media_key": "13_1889129511532281857"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            ],
+                                                                            "symbols": [],
+                                                                            "timestamps": [],
+                                                                            "urls": [],
+                                                                            "user_mentions": []
+                                                                        },
+                                                                        "extended_entities": {
+                                                                            "media": [
+                                                                                {
+                                                                                    "display_url": "pic.x.com/US8rriz3QX",
+                                                                                    "expanded_url": "https://x.com/SenAdamSchiff/status/1889129755133276184/video/1",
+                                                                                    "id_str": "1889129511532281857",
+                                                                                    "indices": [
+                                                                                        76,
+                                                                                        99
+                                                                                    ],
+                                                                                    "media_key": "13_1889129511532281857",
+                                                                                    "media_url_https": "https://pbs.twimg.com/amplify_video_thumb/1889129511532281857/img/E3PEWO_r4xYYNjLZ.jpg",
+                                                                                    "type": "video",
+                                                                                    "url": "https://t.co/US8rriz3QX",
+                                                                                    "additional_media_info": {
+                                                                                        "monetizable": false
+                                                                                    },
+                                                                                    "ext_media_availability": {
+                                                                                        "status": "Available"
+                                                                                    },
+                                                                                    "sizes": {
+                                                                                        "large": {
+                                                                                            "h": 1080,
+                                                                                            "w": 1920,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "medium": {
+                                                                                            "h": 675,
+                                                                                            "w": 1200,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "small": {
+                                                                                            "h": 383,
+                                                                                            "w": 680,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "thumb": {
+                                                                                            "h": 150,
+                                                                                            "w": 150,
+                                                                                            "resize": "crop"
+                                                                                        }
+                                                                                    },
+                                                                                    "original_info": {
+                                                                                        "height": 1080,
+                                                                                        "width": 1920,
+                                                                                        "focus_rects": []
+                                                                                    },
+                                                                                    "video_info": {
+                                                                                        "aspect_ratio": [
+                                                                                            16,
+                                                                                            9
+                                                                                        ],
+                                                                                        "duration_millis": 76309,
+                                                                                        "variants": [
+                                                                                            {
+                                                                                                "content_type": "application/x-mpegURL",
+                                                                                                "url": "https://video.twimg.com/amplify_video/1889129511532281857/pl/3D5ogCWhXOC0Xw7I.m3u8?tag=16&v=d2a"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 288000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/amplify_video/1889129511532281857/vid/avc1/480x270/-AcPeWgwc36_BP_V.mp4?tag=16"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 832000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/amplify_video/1889129511532281857/vid/avc1/640x360/Emq8qgaxvTe0biIW.mp4?tag=16"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 2176000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/amplify_video/1889129511532281857/vid/avc1/1280x720/DVvwo_2mWn-bKAGb.mp4?tag=16"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 10368000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/amplify_video/1889129511532281857/vid/avc1/1920x1080/bucVFAZ-YwmMyy1h.mp4?tag=16"
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    "media_results": {
+                                                                                        "result": {
+                                                                                            "media_key": "13_1889129511532281857"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "favorite_count": 10417,
+                                                                        "favorited": false,
+                                                                        "full_text": "To my Republican colleagues – where do you draw the line with Donald Trump? https://t.co/US8rriz3QX",
+                                                                        "is_quote_status": false,
+                                                                        "lang": "en",
+                                                                        "possibly_sensitive": false,
+                                                                        "possibly_sensitive_editable": true,
+                                                                        "quote_count": 306,
+                                                                        "reply_count": 5285,
+                                                                        "retweet_count": 2639,
+                                                                        "retweeted": true,
+                                                                        "user_id_str": "29501253",
+                                                                        "id_str": "1889129755133276184"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "tweetDisplayType": "Tweet"
+                                            },
+                                            "clientEventInfo": {
+                                                "component": "tweet",
+                                                "element": "tweet",
+                                                "details": {
+                                                    "timelinesDetails": {
+                                                        "injectionType": "RankedOrganicTweet",
+                                                        "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "entryId": "tweet-1889776113729081490",
+                                        "sortIndex": "1908263658341793789",
+                                        "content": {
+                                            "entryType": "TimelineTimelineItem",
+                                            "__typename": "TimelineTimelineItem",
+                                            "itemContent": {
+                                                "itemType": "TimelineTweet",
+                                                "__typename": "TimelineTweet",
+                                                "tweet_results": {
+                                                    "result": {
+                                                        "__typename": "Tweet",
+                                                        "rest_id": "1889776113729081490",
+                                                        "core": {
+                                                            "user_results": {
+                                                                "result": {
+                                                                    "__typename": "User",
+                                                                    "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                    "rest_id": "1769424777998180352",
+                                                                    "affiliates_highlighted_label": {},
+                                                                    "has_graduated_access": false,
+                                                                    "parody_commentary_fan_label": "None",
+                                                                    "is_blue_verified": false,
+                                                                    "profile_image_shape": "Circle",
+                                                                    "legacy": {
+                                                                        "following": false,
+                                                                        "can_dm": true,
+                                                                        "can_media_tag": true,
+                                                                        "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                        "default_profile": true,
+                                                                        "default_profile_image": false,
+                                                                        "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                        "entities": {
+                                                                            "description": {
+                                                                                "urls": []
+                                                                            }
+                                                                        },
+                                                                        "fast_followers_count": 0,
+                                                                        "favourites_count": 124,
+                                                                        "followers_count": 0,
+                                                                        "friends_count": 0,
+                                                                        "has_custom_timelines": false,
+                                                                        "is_translator": false,
+                                                                        "listed_count": 0,
+                                                                        "location": "",
+                                                                        "media_count": 0,
+                                                                        "name": "aurorabyte",
+                                                                        "needs_phone_verification": false,
+                                                                        "normal_followers_count": 0,
+                                                                        "pinned_tweet_ids_str": [],
+                                                                        "possibly_sensitive": false,
+                                                                        "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                        "profile_interstitial_type": "",
+                                                                        "screen_name": "aurorabyte79324",
+                                                                        "statuses_count": 355,
+                                                                        "translator_type": "none",
+                                                                        "verified": false,
+                                                                        "want_retweets": false,
+                                                                        "withheld_in_countries": []
+                                                                    },
+                                                                    "tipjar_settings": {}
+                                                                }
+                                                            }
+                                                        },
+                                                        "unmention_data": {},
+                                                        "edit_control": {
+                                                            "edit_tweet_ids": [
+                                                                "1889776113729081490"
+                                                            ],
+                                                            "editable_until_msecs": "1739396310512",
+                                                            "is_edit_eligible": false,
+                                                            "edits_remaining": "5"
+                                                        },
+                                                        "is_translatable": false,
+                                                        "views": {
+                                                            "state": "Enabled"
+                                                        },
+                                                        "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                        "grok_analysis_button": true,
+                                                        "legacy": {
+                                                            "bookmark_count": 0,
+                                                            "bookmarked": false,
+                                                            "created_at": "Wed Feb 12 20:38:30 +0000 2025",
+                                                            "conversation_id_str": "1889776113729081490",
+                                                            "display_text_range": [
+                                                                0,
+                                                                140
+                                                            ],
+                                                            "entities": {
+                                                                "hashtags": [],
+                                                                "symbols": [],
+                                                                "timestamps": [],
+                                                                "urls": [],
+                                                                "user_mentions": [
+                                                                    {
+                                                                        "id_str": "1390762874809761793",
+                                                                        "name": "Defiant L’s",
+                                                                        "screen_name": "DefiantLs",
+                                                                        "indices": [
+                                                                            3,
+                                                                            13
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "favorite_count": 0,
+                                                            "favorited": false,
+                                                            "full_text": "RT @DefiantLs: CNN Kaitlan Collins: \"We are three weeks into the second Trump presidency, three weeks, and tonight, there are warnings that…",
+                                                            "is_quote_status": false,
+                                                            "lang": "en",
+                                                            "quote_count": 0,
+                                                            "reply_count": 0,
+                                                            "retweet_count": 3898,
+                                                            "retweeted": true,
+                                                            "user_id_str": "1769424777998180352",
+                                                            "id_str": "1889776113729081490",
+                                                            "retweeted_status_result": {
+                                                                "result": {
+                                                                    "__typename": "Tweet",
+                                                                    "rest_id": "1889294793022357511",
+                                                                    "core": {
+                                                                        "user_results": {
+                                                                            "result": {
+                                                                                "__typename": "User",
+                                                                                "id": "VXNlcjoxMzkwNzYyODc0ODA5NzYxNzkz",
+                                                                                "rest_id": "1390762874809761793",
+                                                                                "affiliates_highlighted_label": {
+                                                                                    "label": {
+                                                                                        "url": {
+                                                                                            "url": "https://twitter.com/ResisttheMS",
+                                                                                            "urlType": "DeepLink"
+                                                                                        },
+                                                                                        "badge": {
+                                                                                            "url": "https://pbs.twimg.com/profile_images/1777217835036495872/atU7ay85_bigger.jpg"
+                                                                                        },
+                                                                                        "description": "Resist the Mainstream",
+                                                                                        "userLabelType": "BusinessLabel",
+                                                                                        "userLabelDisplayType": "Badge"
+                                                                                    }
+                                                                                },
+                                                                                "has_graduated_access": true,
+                                                                                "parody_commentary_fan_label": "None",
+                                                                                "is_blue_verified": true,
+                                                                                "profile_image_shape": "Circle",
+                                                                                "legacy": {
+                                                                                    "following": false,
+                                                                                    "can_dm": true,
+                                                                                    "can_media_tag": true,
+                                                                                    "created_at": "Fri May 07 20:18:13 +0000 2021",
+                                                                                    "default_profile": true,
+                                                                                    "default_profile_image": false,
+                                                                                    "description": "Exposing hypocrisy, one day at a time. • DM submissions/biz inquiries",
+                                                                                    "entities": {
+                                                                                        "description": {
+                                                                                            "urls": []
+                                                                                        },
+                                                                                        "url": {
+                                                                                            "urls": [
+                                                                                                {
+                                                                                                    "display_url": "instagram.com/Defiant.Ls",
+                                                                                                    "expanded_url": "http://instagram.com/Defiant.Ls",
+                                                                                                    "url": "https://t.co/xxxjOwrKeu",
+                                                                                                    "indices": [
+                                                                                                        0,
+                                                                                                        23
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "fast_followers_count": 0,
+                                                                                    "favourites_count": 29145,
+                                                                                    "followers_count": 1528068,
+                                                                                    "friends_count": 152,
+                                                                                    "has_custom_timelines": true,
+                                                                                    "is_translator": false,
+                                                                                    "listed_count": 3603,
+                                                                                    "location": "",
+                                                                                    "media_count": 18488,
+                                                                                    "name": "Defiant L’s",
+                                                                                    "normal_followers_count": 1528068,
+                                                                                    "pinned_tweet_ids_str": [
+                                                                                        "1907927230866665554"
+                                                                                    ],
+                                                                                    "possibly_sensitive": false,
+                                                                                    "profile_banner_url": "https://pbs.twimg.com/profile_banners/1390762874809761793/1710377019",
+                                                                                    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1428167484406964229/Q8fS7M5X_normal.jpg",
+                                                                                    "profile_interstitial_type": "",
+                                                                                    "screen_name": "DefiantLs",
+                                                                                    "statuses_count": 29921,
+                                                                                    "translator_type": "none",
+                                                                                    "url": "https://t.co/xxxjOwrKeu",
+                                                                                    "verified": false,
+                                                                                    "want_retweets": false,
+                                                                                    "withheld_in_countries": []
+                                                                                },
+                                                                                "tipjar_settings": {
+                                                                                    "is_enabled": false,
+                                                                                    "cash_app_handle": ""
+                                                                                },
+                                                                                "super_follow_eligible": true
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "unmention_data": {},
+                                                                    "edit_control": {
+                                                                        "edit_tweet_ids": [
+                                                                            "1889294793022357511"
+                                                                        ],
+                                                                        "editable_until_msecs": "1739281554000",
+                                                                        "is_edit_eligible": true,
+                                                                        "edits_remaining": "5"
+                                                                    },
+                                                                    "is_translatable": false,
+                                                                    "views": {
+                                                                        "count": "3160012",
+                                                                        "state": "EnabledWithCount"
+                                                                    },
+                                                                    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                                                                    "grok_analysis_button": true,
+                                                                    "legacy": {
+                                                                        "bookmark_count": 1223,
+                                                                        "bookmarked": false,
+                                                                        "created_at": "Tue Feb 11 12:45:54 +0000 2025",
+                                                                        "conversation_id_str": "1889294793022357511",
+                                                                        "display_text_range": [
+                                                                            0,
+                                                                            208
+                                                                        ],
+                                                                        "entities": {
+                                                                            "hashtags": [],
+                                                                            "media": [
+                                                                                {
+                                                                                    "display_url": "pic.x.com/aZG73QOv80",
+                                                                                    "expanded_url": "https://x.com/brianstelter/status/1889144671231693086/video/1",
+                                                                                    "id_str": "1889144638553939968",
+                                                                                    "indices": [
+                                                                                        185,
+                                                                                        208
+                                                                                    ],
+                                                                                    "media_key": "7_1889144638553939968",
+                                                                                    "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1889144638553939968/pu/img/H_La0RsTlM7BRVIv.jpg",
+                                                                                    "source_status_id_str": "1889144671231693086",
+                                                                                    "source_user_id_str": "14515799",
+                                                                                    "type": "video",
+                                                                                    "url": "https://t.co/aZG73QOv80",
+                                                                                    "additional_media_info": {
+                                                                                        "monetizable": false,
+                                                                                        "source_user": {
+                                                                                            "user_results": {
+                                                                                                "result": {
+                                                                                                    "__typename": "User",
+                                                                                                    "id": "VXNlcjoxNDUxNTc5OQ==",
+                                                                                                    "rest_id": "14515799",
+                                                                                                    "affiliates_highlighted_label": {},
+                                                                                                    "has_graduated_access": true,
+                                                                                                    "parody_commentary_fan_label": "None",
+                                                                                                    "is_blue_verified": true,
+                                                                                                    "profile_image_shape": "Circle",
+                                                                                                    "legacy": {
+                                                                                                        "following": false,
+                                                                                                        "can_dm": true,
+                                                                                                        "can_media_tag": true,
+                                                                                                        "created_at": "Thu Apr 24 18:41:42 +0000 2008",
+                                                                                                        "default_profile": false,
+                                                                                                        "default_profile_image": false,
+                                                                                                        "description": "Chief Media Analyst, @CNN / Host, @VanityFair's Inside the Hive / Author, https://t.co/sGeOrrfY95 / @TheMorningShow producer",
+                                                                                                        "entities": {
+                                                                                                            "description": {
+                                                                                                                "urls": [
+                                                                                                                    {
+                                                                                                                        "display_url": "NetworkOfLies.com",
+                                                                                                                        "expanded_url": "http://NetworkOfLies.com",
+                                                                                                                        "url": "https://t.co/sGeOrrfY95",
+                                                                                                                        "indices": [
+                                                                                                                            74,
+                                                                                                                            97
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            "url": {
+                                                                                                                "urls": [
+                                                                                                                    {
+                                                                                                                        "display_url": "brianstelter.com",
+                                                                                                                        "expanded_url": "http://brianstelter.com",
+                                                                                                                        "url": "https://t.co/dHyENO8o5D",
+                                                                                                                        "indices": [
+                                                                                                                            0,
+                                                                                                                            23
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        },
+                                                                                                        "fast_followers_count": 0,
+                                                                                                        "favourites_count": 341318,
+                                                                                                        "followers_count": 746811,
+                                                                                                        "friends_count": 7850,
+                                                                                                        "has_custom_timelines": true,
+                                                                                                        "is_translator": false,
+                                                                                                        "listed_count": 13473,
+                                                                                                        "location": "New York City",
+                                                                                                        "media_count": 14786,
+                                                                                                        "name": "Brian Stelter",
+                                                                                                        "normal_followers_count": 746811,
+                                                                                                        "pinned_tweet_ids_str": [
+                                                                                                            "1889702049496936861"
+                                                                                                        ],
+                                                                                                        "possibly_sensitive": false,
+                                                                                                        "profile_banner_url": "https://pbs.twimg.com/profile_banners/14515799/1725625794",
+                                                                                                        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1422205879009619973/dEqKHwRt_normal.jpg",
+                                                                                                        "profile_interstitial_type": "",
+                                                                                                        "screen_name": "brianstelter",
+                                                                                                        "statuses_count": 253570,
+                                                                                                        "translator_type": "none",
+                                                                                                        "url": "https://t.co/dHyENO8o5D",
+                                                                                                        "verified": false,
+                                                                                                        "want_retweets": false,
+                                                                                                        "withheld_in_countries": []
+                                                                                                    },
+                                                                                                    "professional": {
+                                                                                                        "rest_id": "1490137704130088970",
+                                                                                                        "professional_type": "Creator",
+                                                                                                        "category": [
+                                                                                                            {
+                                                                                                                "id": 580,
+                                                                                                                "name": "Media & News Company",
+                                                                                                                "icon_name": "IconBriefcaseStroke"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "tipjar_settings": {}
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "ext_media_availability": {
+                                                                                        "status": "Available"
+                                                                                    },
+                                                                                    "sizes": {
+                                                                                        "large": {
+                                                                                            "h": 720,
+                                                                                            "w": 1280,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "medium": {
+                                                                                            "h": 675,
+                                                                                            "w": 1200,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "small": {
+                                                                                            "h": 383,
+                                                                                            "w": 680,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "thumb": {
+                                                                                            "h": 150,
+                                                                                            "w": 150,
+                                                                                            "resize": "crop"
+                                                                                        }
+                                                                                    },
+                                                                                    "original_info": {
+                                                                                        "height": 720,
+                                                                                        "width": 1280,
+                                                                                        "focus_rects": []
+                                                                                    },
+                                                                                    "allow_download_status": {
+                                                                                        "allow_download": true
+                                                                                    },
+                                                                                    "video_info": {
+                                                                                        "aspect_ratio": [
+                                                                                            16,
+                                                                                            9
+                                                                                        ],
+                                                                                        "duration_millis": 55655,
+                                                                                        "variants": [
+                                                                                            {
+                                                                                                "content_type": "application/x-mpegURL",
+                                                                                                "url": "https://video.twimg.com/ext_tw_video/1889144638553939968/pu/pl/pJiA5YyG0NQT2ftB.m3u8?tag=12&v=ec2"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 256000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/ext_tw_video/1889144638553939968/pu/vid/avc1/480x270/5UQeoaYTy07JX9yI.mp4?tag=12"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 832000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/ext_tw_video/1889144638553939968/pu/vid/avc1/640x360/UJLxICcYfOVMZJkf.mp4?tag=12"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 2176000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/ext_tw_video/1889144638553939968/pu/vid/avc1/1280x720/i3pMXFx4pgOaTy_H.mp4?tag=12"
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    "media_results": {
+                                                                                        "result": {
+                                                                                            "media_key": "7_1889144638553939968"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            ],
+                                                                            "symbols": [],
+                                                                            "timestamps": [],
+                                                                            "urls": [],
+                                                                            "user_mentions": []
+                                                                        },
+                                                                        "extended_entities": {
+                                                                            "media": [
+                                                                                {
+                                                                                    "display_url": "pic.x.com/aZG73QOv80",
+                                                                                    "expanded_url": "https://x.com/brianstelter/status/1889144671231693086/video/1",
+                                                                                    "id_str": "1889144638553939968",
+                                                                                    "indices": [
+                                                                                        185,
+                                                                                        208
+                                                                                    ],
+                                                                                    "media_key": "7_1889144638553939968",
+                                                                                    "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1889144638553939968/pu/img/H_La0RsTlM7BRVIv.jpg",
+                                                                                    "source_status_id_str": "1889144671231693086",
+                                                                                    "source_user_id_str": "14515799",
+                                                                                    "type": "video",
+                                                                                    "url": "https://t.co/aZG73QOv80",
+                                                                                    "additional_media_info": {
+                                                                                        "monetizable": false,
+                                                                                        "source_user": {
+                                                                                            "user_results": {
+                                                                                                "result": {
+                                                                                                    "__typename": "User",
+                                                                                                    "id": "VXNlcjoxNDUxNTc5OQ==",
+                                                                                                    "rest_id": "14515799",
+                                                                                                    "affiliates_highlighted_label": {},
+                                                                                                    "has_graduated_access": true,
+                                                                                                    "parody_commentary_fan_label": "None",
+                                                                                                    "is_blue_verified": true,
+                                                                                                    "profile_image_shape": "Circle",
+                                                                                                    "legacy": {
+                                                                                                        "following": false,
+                                                                                                        "can_dm": true,
+                                                                                                        "can_media_tag": true,
+                                                                                                        "created_at": "Thu Apr 24 18:41:42 +0000 2008",
+                                                                                                        "default_profile": false,
+                                                                                                        "default_profile_image": false,
+                                                                                                        "description": "Chief Media Analyst, @CNN / Host, @VanityFair's Inside the Hive / Author, https://t.co/sGeOrrfY95 / @TheMorningShow producer",
+                                                                                                        "entities": {
+                                                                                                            "description": {
+                                                                                                                "urls": [
+                                                                                                                    {
+                                                                                                                        "display_url": "NetworkOfLies.com",
+                                                                                                                        "expanded_url": "http://NetworkOfLies.com",
+                                                                                                                        "url": "https://t.co/sGeOrrfY95",
+                                                                                                                        "indices": [
+                                                                                                                            74,
+                                                                                                                            97
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            "url": {
+                                                                                                                "urls": [
+                                                                                                                    {
+                                                                                                                        "display_url": "brianstelter.com",
+                                                                                                                        "expanded_url": "http://brianstelter.com",
+                                                                                                                        "url": "https://t.co/dHyENO8o5D",
+                                                                                                                        "indices": [
+                                                                                                                            0,
+                                                                                                                            23
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        },
+                                                                                                        "fast_followers_count": 0,
+                                                                                                        "favourites_count": 341318,
+                                                                                                        "followers_count": 746811,
+                                                                                                        "friends_count": 7850,
+                                                                                                        "has_custom_timelines": true,
+                                                                                                        "is_translator": false,
+                                                                                                        "listed_count": 13473,
+                                                                                                        "location": "New York City",
+                                                                                                        "media_count": 14786,
+                                                                                                        "name": "Brian Stelter",
+                                                                                                        "normal_followers_count": 746811,
+                                                                                                        "pinned_tweet_ids_str": [
+                                                                                                            "1889702049496936861"
+                                                                                                        ],
+                                                                                                        "possibly_sensitive": false,
+                                                                                                        "profile_banner_url": "https://pbs.twimg.com/profile_banners/14515799/1725625794",
+                                                                                                        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1422205879009619973/dEqKHwRt_normal.jpg",
+                                                                                                        "profile_interstitial_type": "",
+                                                                                                        "screen_name": "brianstelter",
+                                                                                                        "statuses_count": 253570,
+                                                                                                        "translator_type": "none",
+                                                                                                        "url": "https://t.co/dHyENO8o5D",
+                                                                                                        "verified": false,
+                                                                                                        "want_retweets": false,
+                                                                                                        "withheld_in_countries": []
+                                                                                                    },
+                                                                                                    "professional": {
+                                                                                                        "rest_id": "1490137704130088970",
+                                                                                                        "professional_type": "Creator",
+                                                                                                        "category": [
+                                                                                                            {
+                                                                                                                "id": 580,
+                                                                                                                "name": "Media & News Company",
+                                                                                                                "icon_name": "IconBriefcaseStroke"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "tipjar_settings": {}
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "ext_media_availability": {
+                                                                                        "status": "Available"
+                                                                                    },
+                                                                                    "sizes": {
+                                                                                        "large": {
+                                                                                            "h": 720,
+                                                                                            "w": 1280,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "medium": {
+                                                                                            "h": 675,
+                                                                                            "w": 1200,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "small": {
+                                                                                            "h": 383,
+                                                                                            "w": 680,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "thumb": {
+                                                                                            "h": 150,
+                                                                                            "w": 150,
+                                                                                            "resize": "crop"
+                                                                                        }
+                                                                                    },
+                                                                                    "original_info": {
+                                                                                        "height": 720,
+                                                                                        "width": 1280,
+                                                                                        "focus_rects": []
+                                                                                    },
+                                                                                    "allow_download_status": {
+                                                                                        "allow_download": true
+                                                                                    },
+                                                                                    "video_info": {
+                                                                                        "aspect_ratio": [
+                                                                                            16,
+                                                                                            9
+                                                                                        ],
+                                                                                        "duration_millis": 55655,
+                                                                                        "variants": [
+                                                                                            {
+                                                                                                "content_type": "application/x-mpegURL",
+                                                                                                "url": "https://video.twimg.com/ext_tw_video/1889144638553939968/pu/pl/pJiA5YyG0NQT2ftB.m3u8?tag=12&v=ec2"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 256000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/ext_tw_video/1889144638553939968/pu/vid/avc1/480x270/5UQeoaYTy07JX9yI.mp4?tag=12"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 832000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/ext_tw_video/1889144638553939968/pu/vid/avc1/640x360/UJLxICcYfOVMZJkf.mp4?tag=12"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 2176000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/ext_tw_video/1889144638553939968/pu/vid/avc1/1280x720/i3pMXFx4pgOaTy_H.mp4?tag=12"
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    "media_results": {
+                                                                                        "result": {
+                                                                                            "media_key": "7_1889144638553939968"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "favorite_count": 27840,
+                                                                        "favorited": false,
+                                                                        "full_text": "CNN Kaitlan Collins: \"We are three weeks into the second Trump presidency, three weeks, and tonight, there are warnings that the U.S. is dangerously close to a constitutional crisis.\"\n\nhttps://t.co/aZG73QOv80",
+                                                                        "is_quote_status": false,
+                                                                        "lang": "en",
+                                                                        "possibly_sensitive": false,
+                                                                        "possibly_sensitive_editable": true,
+                                                                        "quote_count": 1317,
+                                                                        "reply_count": 15866,
+                                                                        "retweet_count": 3898,
+                                                                        "retweeted": true,
+                                                                        "user_id_str": "1390762874809761793",
+                                                                        "id_str": "1889294793022357511"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "tweetDisplayType": "Tweet"
+                                            },
+                                            "clientEventInfo": {
+                                                "component": "tweet",
+                                                "element": "tweet",
+                                                "details": {
+                                                    "timelinesDetails": {
+                                                        "injectionType": "RankedOrganicTweet",
+                                                        "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "entryId": "tweet-1889773520437067957",
+                                        "sortIndex": "1908263658341793788",
+                                        "content": {
+                                            "entryType": "TimelineTimelineItem",
+                                            "__typename": "TimelineTimelineItem",
+                                            "itemContent": {
+                                                "itemType": "TimelineTweet",
+                                                "__typename": "TimelineTweet",
+                                                "tweet_results": {
+                                                    "result": {
+                                                        "__typename": "Tweet",
+                                                        "rest_id": "1889773520437067957",
+                                                        "core": {
+                                                            "user_results": {
+                                                                "result": {
+                                                                    "__typename": "User",
+                                                                    "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                    "rest_id": "1769424777998180352",
+                                                                    "affiliates_highlighted_label": {},
+                                                                    "has_graduated_access": false,
+                                                                    "parody_commentary_fan_label": "None",
+                                                                    "is_blue_verified": false,
+                                                                    "profile_image_shape": "Circle",
+                                                                    "legacy": {
+                                                                        "following": false,
+                                                                        "can_dm": true,
+                                                                        "can_media_tag": true,
+                                                                        "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                        "default_profile": true,
+                                                                        "default_profile_image": false,
+                                                                        "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                        "entities": {
+                                                                            "description": {
+                                                                                "urls": []
+                                                                            }
+                                                                        },
+                                                                        "fast_followers_count": 0,
+                                                                        "favourites_count": 124,
+                                                                        "followers_count": 0,
+                                                                        "friends_count": 0,
+                                                                        "has_custom_timelines": false,
+                                                                        "is_translator": false,
+                                                                        "listed_count": 0,
+                                                                        "location": "",
+                                                                        "media_count": 0,
+                                                                        "name": "aurorabyte",
+                                                                        "needs_phone_verification": false,
+                                                                        "normal_followers_count": 0,
+                                                                        "pinned_tweet_ids_str": [],
+                                                                        "possibly_sensitive": false,
+                                                                        "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                        "profile_interstitial_type": "",
+                                                                        "screen_name": "aurorabyte79324",
+                                                                        "statuses_count": 355,
+                                                                        "translator_type": "none",
+                                                                        "verified": false,
+                                                                        "want_retweets": false,
+                                                                        "withheld_in_countries": []
+                                                                    },
+                                                                    "tipjar_settings": {}
+                                                                }
+                                                            }
+                                                        },
+                                                        "unmention_data": {},
+                                                        "edit_control": {
+                                                            "edit_tweet_ids": [
+                                                                "1889773520437067957"
+                                                            ],
+                                                            "editable_until_msecs": "1739395692000",
+                                                            "is_edit_eligible": true,
+                                                            "edits_remaining": "5"
+                                                        },
+                                                        "is_translatable": false,
+                                                        "views": {
+                                                            "count": "2",
+                                                            "state": "EnabledWithCount"
+                                                        },
+                                                        "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                        "grok_analysis_button": true,
+                                                        "legacy": {
+                                                            "bookmark_count": 0,
+                                                            "bookmarked": false,
+                                                            "created_at": "Wed Feb 12 20:28:12 +0000 2025",
+                                                            "conversation_id_str": "1889773520437067957",
+                                                            "display_text_range": [
+                                                                0,
+                                                                50
+                                                            ],
+                                                            "entities": {
+                                                                "hashtags": [],
+                                                                "symbols": [],
+                                                                "timestamps": [],
+                                                                "urls": [],
+                                                                "user_mentions": []
+                                                            },
+                                                            "favorite_count": 0,
+                                                            "favorited": false,
+                                                            "full_text": "Revolutionizing the pixel, one art piece at a time",
+                                                            "is_quote_status": false,
+                                                            "lang": "en",
+                                                            "quote_count": 0,
+                                                            "reply_count": 0,
+                                                            "retweet_count": 0,
+                                                            "retweeted": false,
+                                                            "user_id_str": "1769424777998180352",
+                                                            "id_str": "1889773520437067957"
+                                                        }
+                                                    }
+                                                },
+                                                "tweetDisplayType": "Tweet"
+                                            },
+                                            "clientEventInfo": {
+                                                "component": "tweet",
+                                                "element": "tweet",
+                                                "details": {
+                                                    "timelinesDetails": {
+                                                        "injectionType": "RankedOrganicTweet",
+                                                        "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "entryId": "who-to-follow-1908263658341793797",
+                                        "sortIndex": "1908263658341793787",
+                                        "content": {
+                                            "entryType": "TimelineTimelineModule",
+                                            "__typename": "TimelineTimelineModule",
+                                            "items": [
+                                                {
+                                                    "entryId": "who-to-follow-1908263658341793797-user-667563",
+                                                    "item": {
+                                                        "itemContent": {
+                                                            "itemType": "TimelineUser",
+                                                            "__typename": "TimelineUser",
+                                                            "user_results": {
+                                                                "result": {
+                                                                    "__typename": "User",
+                                                                    "id": "VXNlcjo2Njc1NjM=",
+                                                                    "rest_id": "667563",
+                                                                    "affiliates_highlighted_label": {},
+                                                                    "has_graduated_access": true,
+                                                                    "parody_commentary_fan_label": "None",
+                                                                    "is_blue_verified": true,
+                                                                    "profile_image_shape": "Square",
+                                                                    "legacy": {
+                                                                        "following": false,
+                                                                        "can_dm": false,
+                                                                        "can_media_tag": true,
+                                                                        "created_at": "Fri Jan 19 20:43:16 +0000 2007",
+                                                                        "default_profile": false,
+                                                                        "default_profile_image": false,
+                                                                        "description": "#LightTheBeam",
+                                                                        "entities": {
+                                                                            "description": {
+                                                                                "urls": []
+                                                                            },
+                                                                            "url": {
+                                                                                "urls": [
+                                                                                    {
+                                                                                        "display_url": "Kings.com",
+                                                                                        "expanded_url": "https://Kings.com",
+                                                                                        "url": "https://t.co/83586wCeM3",
+                                                                                        "indices": [
+                                                                                            0,
+                                                                                            23
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "fast_followers_count": 0,
+                                                                        "favourites_count": 7735,
+                                                                        "followers_count": 1266562,
+                                                                        "friends_count": 23325,
+                                                                        "has_custom_timelines": true,
+                                                                        "is_translator": false,
+                                                                        "listed_count": 6317,
+                                                                        "location": "@golden1center",
+                                                                        "media_count": 4260,
+                                                                        "name": "Sacramento Kings",
+                                                                        "normal_followers_count": 1266562,
+                                                                        "pinned_tweet_ids_str": [
+                                                                            "1901877677298000236"
+                                                                        ],
+                                                                        "possibly_sensitive": false,
+                                                                        "profile_banner_url": "https://pbs.twimg.com/profile_banners/667563/1724263010",
+                                                                        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1826317545168924672/Lk0y7bF0_normal.jpg",
+                                                                        "profile_interstitial_type": "",
+                                                                        "screen_name": "SacramentoKings",
+                                                                        "statuses_count": 4208,
+                                                                        "translator_type": "none",
+                                                                        "url": "https://t.co/83586wCeM3",
+                                                                        "verified": false,
+                                                                        "verified_type": "Business",
+                                                                        "want_retweets": false,
+                                                                        "withheld_in_countries": []
+                                                                    },
+                                                                    "professional": {
+                                                                        "rest_id": "1711812638236442839",
+                                                                        "professional_type": "Business",
+                                                                        "category": [
+                                                                            {
+                                                                                "id": 800,
+                                                                                "name": "Sports, Fitness & Recreation",
+                                                                                "icon_name": "IconBriefcaseStroke"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "tipjar_settings": {}
+                                                                }
+                                                            },
+                                                            "userDisplayType": "User"
+                                                        },
+                                                        "clientEventInfo": {
+                                                            "component": "suggest_who_to_follow",
+                                                            "element": "user",
+                                                            "details": {
+                                                                "timelinesDetails": {
+                                                                    "injectionType": "WhoToFollow",
+                                                                    "controllerData": "DAACDAACDAABCgABAAAAAAAAAIAAAAAA",
+                                                                    "sourceData": "DAABCgABbZAD3I4pLkMKAAIAAAAAAAAAAAAIAAIAAAC1CAADAAAAAgwABQwAAgwAAgwAAQoAAQAAAAAAAACAAAAAAAA="
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "entryId": "who-to-follow-1908263658341793797-user-14411304",
+                                                    "item": {
+                                                        "itemContent": {
+                                                            "itemType": "TimelineUser",
+                                                            "__typename": "TimelineUser",
+                                                            "user_results": {
+                                                                "result": {
+                                                                    "__typename": "User",
+                                                                    "id": "VXNlcjoxNDQxMTMwNA==",
+                                                                    "rest_id": "14411304",
+                                                                    "affiliates_highlighted_label": {},
+                                                                    "has_graduated_access": true,
+                                                                    "parody_commentary_fan_label": "None",
+                                                                    "is_blue_verified": false,
+                                                                    "profile_image_shape": "Square",
+                                                                    "legacy": {
+                                                                        "following": false,
+                                                                        "can_dm": true,
+                                                                        "can_media_tag": true,
+                                                                        "created_at": "Wed Apr 16 18:44:06 +0000 2008",
+                                                                        "default_profile": false,
+                                                                        "default_profile_image": false,
+                                                                        "description": "Official account of The Sacramento Bee in California. News, sports, entertainment, politics & more. #ReadLocal\n\nSubscribe today: https://t.co/segasrFnvG",
+                                                                        "entities": {
+                                                                            "description": {
+                                                                                "urls": [
+                                                                                    {
+                                                                                        "display_url": "sacbee.com/subscribe",
+                                                                                        "expanded_url": "http://sacbee.com/subscribe",
+                                                                                        "url": "https://t.co/segasrFnvG",
+                                                                                        "indices": [
+                                                                                            129,
+                                                                                            152
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "url": {
+                                                                                "urls": [
+                                                                                    {
+                                                                                        "display_url": "sacbee.com",
+                                                                                        "expanded_url": "http://www.sacbee.com",
+                                                                                        "url": "http://t.co/UZLsyykb0p",
+                                                                                        "indices": [
+                                                                                            0,
+                                                                                            22
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "fast_followers_count": 0,
+                                                                        "favourites_count": 1113,
+                                                                        "followers_count": 258517,
+                                                                        "friends_count": 78,
+                                                                        "has_custom_timelines": true,
+                                                                        "is_translator": false,
+                                                                        "listed_count": 2998,
+                                                                        "location": "Sacramento, CA",
+                                                                        "media_count": 20388,
+                                                                        "name": "The Sacramento Bee",
+                                                                        "normal_followers_count": 258517,
+                                                                        "pinned_tweet_ids_str": [],
+                                                                        "possibly_sensitive": false,
+                                                                        "profile_banner_url": "https://pbs.twimg.com/profile_banners/14411304/1478682740",
+                                                                        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1421538328021721089/oMTaYh9R_normal.jpg",
+                                                                        "profile_interstitial_type": "",
+                                                                        "screen_name": "sacbee_news",
+                                                                        "statuses_count": 399861,
+                                                                        "translator_type": "none",
+                                                                        "url": "http://t.co/UZLsyykb0p",
+                                                                        "verified": false,
+                                                                        "verified_type": "Business",
+                                                                        "want_retweets": false,
+                                                                        "withheld_in_countries": []
+                                                                    },
+                                                                    "tipjar_settings": {}
+                                                                }
+                                                            },
+                                                            "userDisplayType": "User"
+                                                        },
+                                                        "clientEventInfo": {
+                                                            "component": "suggest_who_to_follow",
+                                                            "element": "user",
+                                                            "details": {
+                                                                "timelinesDetails": {
+                                                                    "injectionType": "WhoToFollow",
+                                                                    "controllerData": "DAACDAACDAABCgABAAAAAAAAAIAAAAAA",
+                                                                    "sourceData": "DAABCgABbZAD3I4pLkMKAAIAAAAAAAAAAAAIAAIAAAC1CAADAAAAAgwABQwAAgwAAgwAAQoAAQAAAAAAAACAAAAAAAA="
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "entryId": "who-to-follow-1908263658341793797-user-237814442",
+                                                    "item": {
+                                                        "itemContent": {
+                                                            "itemType": "TimelineUser",
+                                                            "__typename": "TimelineUser",
+                                                            "user_results": {
+                                                                "result": {
+                                                                    "__typename": "User",
+                                                                    "id": "VXNlcjoyMzc4MTQ0NDI=",
+                                                                    "rest_id": "237814442",
+                                                                    "affiliates_highlighted_label": {},
+                                                                    "has_graduated_access": true,
+                                                                    "parody_commentary_fan_label": "None",
+                                                                    "is_blue_verified": false,
+                                                                    "profile_image_shape": "Circle",
+                                                                    "legacy": {
+                                                                        "following": false,
+                                                                        "can_dm": false,
+                                                                        "can_media_tag": true,
+                                                                        "created_at": "Thu Jan 13 18:02:17 +0000 2011",
+                                                                        "default_profile": true,
+                                                                        "default_profile_image": false,
+                                                                        "description": "Providing nonpartisan fiscal and policy advice to the California Legislature for more than 80 years.",
+                                                                        "entities": {
+                                                                            "description": {
+                                                                                "urls": []
+                                                                            },
+                                                                            "url": {
+                                                                                "urls": [
+                                                                                    {
+                                                                                        "display_url": "lao.ca.gov",
+                                                                                        "expanded_url": "http://lao.ca.gov",
+                                                                                        "url": "https://t.co/00Vs6ZXa3N",
+                                                                                        "indices": [
+                                                                                            0,
+                                                                                            23
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "fast_followers_count": 0,
+                                                                        "favourites_count": 0,
+                                                                        "followers_count": 14298,
+                                                                        "friends_count": 1,
+                                                                        "has_custom_timelines": false,
+                                                                        "is_translator": false,
+                                                                        "listed_count": 313,
+                                                                        "location": "Sacramento, California",
+                                                                        "media_count": 1120,
+                                                                        "name": "Legislative Analyst",
+                                                                        "normal_followers_count": 14298,
+                                                                        "pinned_tweet_ids_str": [],
+                                                                        "possibly_sensitive": false,
+                                                                        "profile_banner_url": "https://pbs.twimg.com/profile_banners/237814442/1400620356",
+                                                                        "profile_image_url_https": "https://pbs.twimg.com/profile_images/879845457362538496/zwPO-jcm_normal.jpg",
+                                                                        "profile_interstitial_type": "",
+                                                                        "screen_name": "LAO_CA",
+                                                                        "statuses_count": 3560,
+                                                                        "translator_type": "none",
+                                                                        "url": "https://t.co/00Vs6ZXa3N",
+                                                                        "verified": false,
+                                                                        "want_retweets": false,
+                                                                        "withheld_in_countries": []
+                                                                    },
+                                                                    "tipjar_settings": {}
+                                                                }
+                                                            },
+                                                            "userDisplayType": "User"
+                                                        },
+                                                        "clientEventInfo": {
+                                                            "component": "suggest_who_to_follow",
+                                                            "element": "user",
+                                                            "details": {
+                                                                "timelinesDetails": {
+                                                                    "injectionType": "WhoToFollow",
+                                                                    "controllerData": "DAACDAACDAABCgABAAAAAAAAAIAAAAAA",
+                                                                    "sourceData": "DAABCgABbZAD3I4pLkMKAAIAAAAAAAAAAAAIAAIAAAC1CAADAAAAAgwABQwAAgwAAgwAAQoAAQAAAAAAAACAAAAAAAA="
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "displayType": "Vertical",
+                                            "header": {
+                                                "displayType": "Classic",
+                                                "text": "Who to follow",
+                                                "sticky": false
+                                            },
+                                            "footer": {
+                                                "displayType": "Classic",
+                                                "text": "Show more",
+                                                "landingUrl": {
+                                                    "url": "twitter://connect_people?user_id=1769424777998180352&display_location=profile_wtf_showmore",
+                                                    "urlType": "DeepLink"
+                                                }
+                                            },
+                                            "clientEventInfo": {
+                                                "component": "suggest_who_to_follow",
+                                                "details": {
+                                                    "timelinesDetails": {
+                                                        "injectionType": "WhoToFollow",
+                                                        "controllerData": "DAACDAACDAABCgABAAAAAAAAAIAAAAAA",
+                                                        "sourceData": "DAABCgABbZAD3I4pLkMKAAIAAAAAAAAAAAAIAAIAAAC1CAADAAAAAgwABQwAAgwAAgwAAQoAAQAAAAAAAACAAAAAAAA="
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "entryId": "profile-conversation-1908263658341793798",
+                                        "sortIndex": "1908263658341793786",
+                                        "content": {
+                                            "entryType": "TimelineTimelineModule",
+                                            "__typename": "TimelineTimelineModule",
+                                            "items": [
+                                                {
+                                                    "entryId": "profile-conversation-1908263658341793798-tweet-1889763065991659755",
+                                                    "dispensable": true,
+                                                    "item": {
+                                                        "itemContent": {
+                                                            "itemType": "TimelineTweet",
+                                                            "__typename": "TimelineTweet",
+                                                            "tweet_results": {
+                                                                "result": {
+                                                                    "__typename": "Tweet",
+                                                                    "rest_id": "1889763065991659755",
+                                                                    "core": {
+                                                                        "user_results": {
+                                                                            "result": {
+                                                                                "__typename": "User",
+                                                                                "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                                "rest_id": "1769424777998180352",
+                                                                                "affiliates_highlighted_label": {},
+                                                                                "has_graduated_access": false,
+                                                                                "parody_commentary_fan_label": "None",
+                                                                                "is_blue_verified": false,
+                                                                                "profile_image_shape": "Circle",
+                                                                                "legacy": {
+                                                                                    "following": false,
+                                                                                    "can_dm": true,
+                                                                                    "can_media_tag": true,
+                                                                                    "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                                    "default_profile": true,
+                                                                                    "default_profile_image": false,
+                                                                                    "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                                    "entities": {
+                                                                                        "description": {
+                                                                                            "urls": []
+                                                                                        }
+                                                                                    },
+                                                                                    "fast_followers_count": 0,
+                                                                                    "favourites_count": 124,
+                                                                                    "followers_count": 0,
+                                                                                    "friends_count": 0,
+                                                                                    "has_custom_timelines": false,
+                                                                                    "is_translator": false,
+                                                                                    "listed_count": 0,
+                                                                                    "location": "",
+                                                                                    "media_count": 0,
+                                                                                    "name": "aurorabyte",
+                                                                                    "needs_phone_verification": false,
+                                                                                    "normal_followers_count": 0,
+                                                                                    "pinned_tweet_ids_str": [],
+                                                                                    "possibly_sensitive": false,
+                                                                                    "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                                    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                                    "profile_interstitial_type": "",
+                                                                                    "screen_name": "aurorabyte79324",
+                                                                                    "statuses_count": 355,
+                                                                                    "translator_type": "none",
+                                                                                    "verified": false,
+                                                                                    "want_retweets": false,
+                                                                                    "withheld_in_countries": []
+                                                                                },
+                                                                                "tipjar_settings": {}
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "unmention_data": {},
+                                                                    "edit_control": {
+                                                                        "edit_tweet_ids": [
+                                                                            "1889763065991659755"
+                                                                        ],
+                                                                        "editable_until_msecs": "1739393199000",
+                                                                        "is_edit_eligible": false,
+                                                                        "edits_remaining": "5"
+                                                                    },
+                                                                    "is_translatable": false,
+                                                                    "views": {
+                                                                        "count": "14",
+                                                                        "state": "EnabledWithCount"
+                                                                    },
+                                                                    "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                                    "grok_analysis_button": true,
+                                                                    "legacy": {
+                                                                        "bookmark_count": 0,
+                                                                        "bookmarked": false,
+                                                                        "created_at": "Wed Feb 12 19:46:39 +0000 2025",
+                                                                        "conversation_id_str": "1889763065991659755",
+                                                                        "display_text_range": [
+                                                                            0,
+                                                                            36
+                                                                        ],
+                                                                        "entities": {
+                                                                            "hashtags": [],
+                                                                            "symbols": [],
+                                                                            "timestamps": [],
+                                                                            "urls": [],
+                                                                            "user_mentions": []
+                                                                        },
+                                                                        "favorite_count": 0,
+                                                                        "favorited": false,
+                                                                        "full_text": "From digital chaos to artistic order",
+                                                                        "is_quote_status": false,
+                                                                        "lang": "en",
+                                                                        "quote_count": 0,
+                                                                        "reply_count": 1,
+                                                                        "retweet_count": 0,
+                                                                        "retweeted": false,
+                                                                        "user_id_str": "1769424777998180352",
+                                                                        "id_str": "1889763065991659755"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "tweetDisplayType": "Tweet"
+                                                        },
+                                                        "clientEventInfo": {
+                                                            "component": "tweet",
+                                                            "element": "tweet",
+                                                            "details": {
+                                                                "timelinesDetails": {
+                                                                    "injectionType": "RankedOrganicTweet",
+                                                                    "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "entryId": "profile-conversation-1908263658341793798-tweet-1889765713734410697",
+                                                    "dispensable": false,
+                                                    "item": {
+                                                        "itemContent": {
+                                                            "itemType": "TimelineTweet",
+                                                            "__typename": "TimelineTweet",
+                                                            "tweet_results": {
+                                                                "result": {
+                                                                    "__typename": "Tweet",
+                                                                    "rest_id": "1889765713734410697",
+                                                                    "core": {
+                                                                        "user_results": {
+                                                                            "result": {
+                                                                                "__typename": "User",
+                                                                                "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                                "rest_id": "1769424777998180352",
+                                                                                "affiliates_highlighted_label": {},
+                                                                                "has_graduated_access": false,
+                                                                                "parody_commentary_fan_label": "None",
+                                                                                "is_blue_verified": false,
+                                                                                "profile_image_shape": "Circle",
+                                                                                "legacy": {
+                                                                                    "following": false,
+                                                                                    "can_dm": true,
+                                                                                    "can_media_tag": true,
+                                                                                    "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                                    "default_profile": true,
+                                                                                    "default_profile_image": false,
+                                                                                    "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                                    "entities": {
+                                                                                        "description": {
+                                                                                            "urls": []
+                                                                                        }
+                                                                                    },
+                                                                                    "fast_followers_count": 0,
+                                                                                    "favourites_count": 124,
+                                                                                    "followers_count": 0,
+                                                                                    "friends_count": 0,
+                                                                                    "has_custom_timelines": false,
+                                                                                    "is_translator": false,
+                                                                                    "listed_count": 0,
+                                                                                    "location": "",
+                                                                                    "media_count": 0,
+                                                                                    "name": "aurorabyte",
+                                                                                    "needs_phone_verification": false,
+                                                                                    "normal_followers_count": 0,
+                                                                                    "pinned_tweet_ids_str": [],
+                                                                                    "possibly_sensitive": false,
+                                                                                    "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                                    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                                    "profile_interstitial_type": "",
+                                                                                    "screen_name": "aurorabyte79324",
+                                                                                    "statuses_count": 355,
+                                                                                    "translator_type": "none",
+                                                                                    "verified": false,
+                                                                                    "want_retweets": false,
+                                                                                    "withheld_in_countries": []
+                                                                                },
+                                                                                "tipjar_settings": {}
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "unmention_data": {},
+                                                                    "edit_control": {
+                                                                        "edit_tweet_ids": [
+                                                                            "1889765713734410697"
+                                                                        ],
+                                                                        "editable_until_msecs": "1739393830000",
+                                                                        "is_edit_eligible": false,
+                                                                        "edits_remaining": "5"
+                                                                    },
+                                                                    "is_translatable": false,
+                                                                    "views": {
+                                                                        "count": "2",
+                                                                        "state": "EnabledWithCount"
+                                                                    },
+                                                                    "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                                    "grok_analysis_button": true,
+                                                                    "legacy": {
+                                                                        "bookmark_count": 0,
+                                                                        "bookmarked": false,
+                                                                        "created_at": "Wed Feb 12 19:57:10 +0000 2025",
+                                                                        "conversation_id_str": "1889763065991659755",
+                                                                        "display_text_range": [
+                                                                            0,
+                                                                            42
+                                                                        ],
+                                                                        "entities": {
+                                                                            "hashtags": [],
+                                                                            "symbols": [],
+                                                                            "timestamps": [],
+                                                                            "urls": [],
+                                                                            "user_mentions": []
+                                                                        },
+                                                                        "favorite_count": 0,
+                                                                        "favorited": false,
+                                                                        "full_text": "Envisioning the digital renaissance of art",
+                                                                        "in_reply_to_screen_name": "aurorabyte79324",
+                                                                        "in_reply_to_status_id_str": "1889763065991659755",
+                                                                        "in_reply_to_user_id_str": "1769424777998180352",
+                                                                        "is_quote_status": false,
+                                                                        "lang": "en",
+                                                                        "quote_count": 0,
+                                                                        "reply_count": 0,
+                                                                        "retweet_count": 0,
+                                                                        "retweeted": false,
+                                                                        "user_id_str": "1769424777998180352",
+                                                                        "id_str": "1889765713734410697"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "tweetDisplayType": "Tweet"
+                                                        },
+                                                        "clientEventInfo": {
+                                                            "component": "tweet",
+                                                            "element": "tweet",
+                                                            "details": {
+                                                                "timelinesDetails": {
+                                                                    "injectionType": "RankedOrganicTweet",
+                                                                    "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "metadata": {
+                                                "conversationMetadata": {
+                                                    "allTweetIds": [
+                                                        "1889763065991659755",
+                                                        "1889765713734410697"
+                                                    ],
+                                                    "enableDeduplication": true
+                                                }
+                                            },
+                                            "displayType": "VerticalConversation",
+                                            "clientEventInfo": {
+                                                "component": "suggest_ranked_organic_tweet",
+                                                "details": {
+                                                    "timelinesDetails": {
+                                                        "injectionType": "RankedOrganicTweet",
+                                                        "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "entryId": "profile-conversation-1908263658341793799",
+                                        "sortIndex": "1908263658341793785",
+                                        "content": {
+                                            "entryType": "TimelineTimelineModule",
+                                            "__typename": "TimelineTimelineModule",
+                                            "items": [
+                                                {
+                                                    "entryId": "profile-conversation-1908263658341793799-tweet-1889765673691201785",
+                                                    "dispensable": false,
+                                                    "item": {
+                                                        "itemContent": {
+                                                            "itemType": "TimelineTweet",
+                                                            "__typename": "TimelineTweet",
+                                                            "tweet_results": {
+                                                                "result": {
+                                                                    "__typename": "Tweet",
+                                                                    "rest_id": "1889765673691201785",
+                                                                    "core": {
+                                                                        "user_results": {
+                                                                            "result": {
+                                                                                "__typename": "User",
+                                                                                "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                                "rest_id": "1769424777998180352",
+                                                                                "affiliates_highlighted_label": {},
+                                                                                "has_graduated_access": false,
+                                                                                "parody_commentary_fan_label": "None",
+                                                                                "is_blue_verified": false,
+                                                                                "profile_image_shape": "Circle",
+                                                                                "legacy": {
+                                                                                    "following": false,
+                                                                                    "can_dm": true,
+                                                                                    "can_media_tag": true,
+                                                                                    "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                                    "default_profile": true,
+                                                                                    "default_profile_image": false,
+                                                                                    "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                                    "entities": {
+                                                                                        "description": {
+                                                                                            "urls": []
+                                                                                        }
+                                                                                    },
+                                                                                    "fast_followers_count": 0,
+                                                                                    "favourites_count": 124,
+                                                                                    "followers_count": 0,
+                                                                                    "friends_count": 0,
+                                                                                    "has_custom_timelines": false,
+                                                                                    "is_translator": false,
+                                                                                    "listed_count": 0,
+                                                                                    "location": "",
+                                                                                    "media_count": 0,
+                                                                                    "name": "aurorabyte",
+                                                                                    "needs_phone_verification": false,
+                                                                                    "normal_followers_count": 0,
+                                                                                    "pinned_tweet_ids_str": [],
+                                                                                    "possibly_sensitive": false,
+                                                                                    "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                                    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                                    "profile_interstitial_type": "",
+                                                                                    "screen_name": "aurorabyte79324",
+                                                                                    "statuses_count": 355,
+                                                                                    "translator_type": "none",
+                                                                                    "verified": false,
+                                                                                    "want_retweets": false,
+                                                                                    "withheld_in_countries": []
+                                                                                },
+                                                                                "tipjar_settings": {}
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "unmention_data": {},
+                                                                    "edit_control": {
+                                                                        "edit_tweet_ids": [
+                                                                            "1889765673691201785"
+                                                                        ],
+                                                                        "editable_until_msecs": "1739393821000",
+                                                                        "is_edit_eligible": false,
+                                                                        "edits_remaining": "5"
+                                                                    },
+                                                                    "is_translatable": false,
+                                                                    "views": {
+                                                                        "count": "4",
+                                                                        "state": "EnabledWithCount"
+                                                                    },
+                                                                    "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                                    "grok_analysis_button": true,
+                                                                    "legacy": {
+                                                                        "bookmark_count": 0,
+                                                                        "bookmarked": false,
+                                                                        "created_at": "Wed Feb 12 19:57:01 +0000 2025",
+                                                                        "conversation_id_str": "1889762934848626695",
+                                                                        "display_text_range": [
+                                                                            15,
+                                                                            51
+                                                                        ],
+                                                                        "entities": {
+                                                                            "hashtags": [],
+                                                                            "symbols": [],
+                                                                            "timestamps": [],
+                                                                            "urls": [],
+                                                                            "user_mentions": [
+                                                                                {
+                                                                                    "id_str": "1769426369526771712",
+                                                                                    "name": "nexamind",
+                                                                                    "screen_name": "nexamind91326",
+                                                                                    "indices": [
+                                                                                        0,
+                                                                                        14
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "favorite_count": 0,
+                                                                        "favorited": false,
+                                                                        "full_text": "@nexamind91326 From digital chaos to artistic order",
+                                                                        "in_reply_to_screen_name": "nexamind91326",
+                                                                        "in_reply_to_status_id_str": "1889765541784531112",
+                                                                        "in_reply_to_user_id_str": "1769426369526771712",
+                                                                        "is_quote_status": false,
+                                                                        "lang": "en",
+                                                                        "quote_count": 0,
+                                                                        "reply_count": 0,
+                                                                        "retweet_count": 0,
+                                                                        "retweeted": false,
+                                                                        "user_id_str": "1769424777998180352",
+                                                                        "id_str": "1889765673691201785"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "tweetDisplayType": "Tweet"
+                                                        },
+                                                        "clientEventInfo": {
+                                                            "component": "tweet",
+                                                            "element": "tweet",
+                                                            "details": {
+                                                                "timelinesDetails": {
+                                                                    "injectionType": "RankedOrganicTweet",
+                                                                    "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "metadata": {
+                                                "conversationMetadata": {
+                                                    "allTweetIds": [
+                                                        "1889762934848626695",
+                                                        "1889765541784531112",
+                                                        "1889765673691201785"
+                                                    ],
+                                                    "enableDeduplication": true
+                                                }
+                                            },
+                                            "displayType": "VerticalConversation",
+                                            "clientEventInfo": {
+                                                "component": "suggest_ranked_organic_tweet",
+                                                "details": {
+                                                    "timelinesDetails": {
+                                                        "injectionType": "RankedOrganicTweet",
+                                                        "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "entryId": "profile-conversation-1908263658341793800",
+                                        "sortIndex": "1908263658341793784",
+                                        "content": {
+                                            "entryType": "TimelineTimelineModule",
+                                            "__typename": "TimelineTimelineModule",
+                                            "items": [
+                                                {
+                                                    "entryId": "profile-conversation-1908263658341793800-tweet-1889752613794574729",
+                                                    "dispensable": true,
+                                                    "item": {
+                                                        "itemContent": {
+                                                            "itemType": "TimelineTweet",
+                                                            "__typename": "TimelineTweet",
+                                                            "tweet_results": {
+                                                                "result": {
+                                                                    "__typename": "Tweet",
+                                                                    "rest_id": "1889752613794574729",
+                                                                    "core": {
+                                                                        "user_results": {
+                                                                            "result": {
+                                                                                "__typename": "User",
+                                                                                "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                                "rest_id": "1769424777998180352",
+                                                                                "affiliates_highlighted_label": {},
+                                                                                "has_graduated_access": false,
+                                                                                "parody_commentary_fan_label": "None",
+                                                                                "is_blue_verified": false,
+                                                                                "profile_image_shape": "Circle",
+                                                                                "legacy": {
+                                                                                    "following": false,
+                                                                                    "can_dm": true,
+                                                                                    "can_media_tag": true,
+                                                                                    "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                                    "default_profile": true,
+                                                                                    "default_profile_image": false,
+                                                                                    "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                                    "entities": {
+                                                                                        "description": {
+                                                                                            "urls": []
+                                                                                        }
+                                                                                    },
+                                                                                    "fast_followers_count": 0,
+                                                                                    "favourites_count": 124,
+                                                                                    "followers_count": 0,
+                                                                                    "friends_count": 0,
+                                                                                    "has_custom_timelines": false,
+                                                                                    "is_translator": false,
+                                                                                    "listed_count": 0,
+                                                                                    "location": "",
+                                                                                    "media_count": 0,
+                                                                                    "name": "aurorabyte",
+                                                                                    "needs_phone_verification": false,
+                                                                                    "normal_followers_count": 0,
+                                                                                    "pinned_tweet_ids_str": [],
+                                                                                    "possibly_sensitive": false,
+                                                                                    "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                                    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                                    "profile_interstitial_type": "",
+                                                                                    "screen_name": "aurorabyte79324",
+                                                                                    "statuses_count": 355,
+                                                                                    "translator_type": "none",
+                                                                                    "verified": false,
+                                                                                    "want_retweets": false,
+                                                                                    "withheld_in_countries": []
+                                                                                },
+                                                                                "tipjar_settings": {}
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "unmention_data": {},
+                                                                    "edit_control": {
+                                                                        "edit_tweet_ids": [
+                                                                            "1889752613794574729"
+                                                                        ],
+                                                                        "editable_until_msecs": "1739390707000",
+                                                                        "is_edit_eligible": false,
+                                                                        "edits_remaining": "5"
+                                                                    },
+                                                                    "is_translatable": false,
+                                                                    "views": {
+                                                                        "count": "8",
+                                                                        "state": "EnabledWithCount"
+                                                                    },
+                                                                    "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                                    "grok_analysis_button": true,
+                                                                    "legacy": {
+                                                                        "bookmark_count": 0,
+                                                                        "bookmarked": false,
+                                                                        "created_at": "Wed Feb 12 19:05:07 +0000 2025",
+                                                                        "conversation_id_str": "1889752613794574729",
+                                                                        "display_text_range": [
+                                                                            0,
+                                                                            33
+                                                                        ],
+                                                                        "entities": {
+                                                                            "hashtags": [],
+                                                                            "symbols": [],
+                                                                            "timestamps": [],
+                                                                            "urls": [],
+                                                                            "user_mentions": []
+                                                                        },
+                                                                        "favorite_count": 0,
+                                                                        "favorited": false,
+                                                                        "full_text": "Innovating beauty, pixel by pixel",
+                                                                        "is_quote_status": false,
+                                                                        "lang": "en",
+                                                                        "quote_count": 0,
+                                                                        "reply_count": 1,
+                                                                        "retweet_count": 0,
+                                                                        "retweeted": false,
+                                                                        "user_id_str": "1769424777998180352",
+                                                                        "id_str": "1889752613794574729"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "tweetDisplayType": "Tweet"
+                                                        },
+                                                        "clientEventInfo": {
+                                                            "component": "tweet",
+                                                            "element": "tweet",
+                                                            "details": {
+                                                                "timelinesDetails": {
+                                                                    "injectionType": "RankedOrganicTweet",
+                                                                    "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "entryId": "profile-conversation-1908263658341793800-tweet-1889757866090717331",
+                                                    "dispensable": false,
+                                                    "item": {
+                                                        "itemContent": {
+                                                            "itemType": "TimelineTweet",
+                                                            "__typename": "TimelineTweet",
+                                                            "tweet_results": {
+                                                                "result": {
+                                                                    "__typename": "Tweet",
+                                                                    "rest_id": "1889757866090717331",
+                                                                    "core": {
+                                                                        "user_results": {
+                                                                            "result": {
+                                                                                "__typename": "User",
+                                                                                "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                                "rest_id": "1769424777998180352",
+                                                                                "affiliates_highlighted_label": {},
+                                                                                "has_graduated_access": false,
+                                                                                "parody_commentary_fan_label": "None",
+                                                                                "is_blue_verified": false,
+                                                                                "profile_image_shape": "Circle",
+                                                                                "legacy": {
+                                                                                    "following": false,
+                                                                                    "can_dm": true,
+                                                                                    "can_media_tag": true,
+                                                                                    "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                                    "default_profile": true,
+                                                                                    "default_profile_image": false,
+                                                                                    "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                                    "entities": {
+                                                                                        "description": {
+                                                                                            "urls": []
+                                                                                        }
+                                                                                    },
+                                                                                    "fast_followers_count": 0,
+                                                                                    "favourites_count": 124,
+                                                                                    "followers_count": 0,
+                                                                                    "friends_count": 0,
+                                                                                    "has_custom_timelines": false,
+                                                                                    "is_translator": false,
+                                                                                    "listed_count": 0,
+                                                                                    "location": "",
+                                                                                    "media_count": 0,
+                                                                                    "name": "aurorabyte",
+                                                                                    "needs_phone_verification": false,
+                                                                                    "normal_followers_count": 0,
+                                                                                    "pinned_tweet_ids_str": [],
+                                                                                    "possibly_sensitive": false,
+                                                                                    "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                                    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                                    "profile_interstitial_type": "",
+                                                                                    "screen_name": "aurorabyte79324",
+                                                                                    "statuses_count": 355,
+                                                                                    "translator_type": "none",
+                                                                                    "verified": false,
+                                                                                    "want_retweets": false,
+                                                                                    "withheld_in_countries": []
+                                                                                },
+                                                                                "tipjar_settings": {}
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "unmention_data": {},
+                                                                    "edit_control": {
+                                                                        "edit_tweet_ids": [
+                                                                            "1889757866090717331"
+                                                                        ],
+                                                                        "editable_until_msecs": "1739391959000",
+                                                                        "is_edit_eligible": false,
+                                                                        "edits_remaining": "5"
+                                                                    },
+                                                                    "is_translatable": false,
+                                                                    "views": {
+                                                                        "count": "2",
+                                                                        "state": "EnabledWithCount"
+                                                                    },
+                                                                    "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                                    "grok_analysis_button": true,
+                                                                    "legacy": {
+                                                                        "bookmark_count": 0,
+                                                                        "bookmarked": false,
+                                                                        "created_at": "Wed Feb 12 19:25:59 +0000 2025",
+                                                                        "conversation_id_str": "1889752613794574729",
+                                                                        "display_text_range": [
+                                                                            0,
+                                                                            42
+                                                                        ],
+                                                                        "entities": {
+                                                                            "hashtags": [],
+                                                                            "symbols": [],
+                                                                            "timestamps": [],
+                                                                            "urls": [],
+                                                                            "user_mentions": []
+                                                                        },
+                                                                        "favorite_count": 0,
+                                                                        "favorited": false,
+                                                                        "full_text": "Transforming data into visual masterpieces",
+                                                                        "in_reply_to_screen_name": "aurorabyte79324",
+                                                                        "in_reply_to_status_id_str": "1889752613794574729",
+                                                                        "in_reply_to_user_id_str": "1769424777998180352",
+                                                                        "is_quote_status": false,
+                                                                        "lang": "pt",
+                                                                        "quote_count": 0,
+                                                                        "reply_count": 0,
+                                                                        "retweet_count": 0,
+                                                                        "retweeted": false,
+                                                                        "user_id_str": "1769424777998180352",
+                                                                        "id_str": "1889757866090717331"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "tweetDisplayType": "Tweet"
+                                                        },
+                                                        "clientEventInfo": {
+                                                            "component": "tweet",
+                                                            "element": "tweet",
+                                                            "details": {
+                                                                "timelinesDetails": {
+                                                                    "injectionType": "RankedOrganicTweet",
+                                                                    "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "metadata": {
+                                                "conversationMetadata": {
+                                                    "allTweetIds": [
+                                                        "1889752613794574729",
+                                                        "1889757866090717331"
+                                                    ],
+                                                    "enableDeduplication": true
+                                                }
+                                            },
+                                            "displayType": "VerticalConversation",
+                                            "clientEventInfo": {
+                                                "component": "suggest_ranked_organic_tweet",
+                                                "details": {
+                                                    "timelinesDetails": {
+                                                        "injectionType": "RankedOrganicTweet",
+                                                        "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "entryId": "profile-conversation-1908263658341793801",
+                                        "sortIndex": "1908263658341793783",
+                                        "content": {
+                                            "entryType": "TimelineTimelineModule",
+                                            "__typename": "TimelineTimelineModule",
+                                            "items": [
+                                                {
+                                                    "entryId": "profile-conversation-1908263658341793801-tweet-1889757822608712180",
+                                                    "dispensable": false,
+                                                    "item": {
+                                                        "itemContent": {
+                                                            "itemType": "TimelineTweet",
+                                                            "__typename": "TimelineTweet",
+                                                            "tweet_results": {
+                                                                "result": {
+                                                                    "__typename": "Tweet",
+                                                                    "rest_id": "1889757822608712180",
+                                                                    "core": {
+                                                                        "user_results": {
+                                                                            "result": {
+                                                                                "__typename": "User",
+                                                                                "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                                "rest_id": "1769424777998180352",
+                                                                                "affiliates_highlighted_label": {},
+                                                                                "has_graduated_access": false,
+                                                                                "parody_commentary_fan_label": "None",
+                                                                                "is_blue_verified": false,
+                                                                                "profile_image_shape": "Circle",
+                                                                                "legacy": {
+                                                                                    "following": false,
+                                                                                    "can_dm": true,
+                                                                                    "can_media_tag": true,
+                                                                                    "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                                    "default_profile": true,
+                                                                                    "default_profile_image": false,
+                                                                                    "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                                    "entities": {
+                                                                                        "description": {
+                                                                                            "urls": []
+                                                                                        }
+                                                                                    },
+                                                                                    "fast_followers_count": 0,
+                                                                                    "favourites_count": 124,
+                                                                                    "followers_count": 0,
+                                                                                    "friends_count": 0,
+                                                                                    "has_custom_timelines": false,
+                                                                                    "is_translator": false,
+                                                                                    "listed_count": 0,
+                                                                                    "location": "",
+                                                                                    "media_count": 0,
+                                                                                    "name": "aurorabyte",
+                                                                                    "needs_phone_verification": false,
+                                                                                    "normal_followers_count": 0,
+                                                                                    "pinned_tweet_ids_str": [],
+                                                                                    "possibly_sensitive": false,
+                                                                                    "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                                    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                                    "profile_interstitial_type": "",
+                                                                                    "screen_name": "aurorabyte79324",
+                                                                                    "statuses_count": 355,
+                                                                                    "translator_type": "none",
+                                                                                    "verified": false,
+                                                                                    "want_retweets": false,
+                                                                                    "withheld_in_countries": []
+                                                                                },
+                                                                                "tipjar_settings": {}
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "unmention_data": {},
+                                                                    "edit_control": {
+                                                                        "edit_tweet_ids": [
+                                                                            "1889757822608712180"
+                                                                        ],
+                                                                        "editable_until_msecs": "1739391949000",
+                                                                        "is_edit_eligible": false,
+                                                                        "edits_remaining": "5"
+                                                                    },
+                                                                    "is_translatable": false,
+                                                                    "views": {
+                                                                        "count": "4",
+                                                                        "state": "EnabledWithCount"
+                                                                    },
+                                                                    "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                                    "grok_analysis_button": true,
+                                                                    "legacy": {
+                                                                        "bookmark_count": 0,
+                                                                        "bookmarked": false,
+                                                                        "created_at": "Wed Feb 12 19:25:49 +0000 2025",
+                                                                        "conversation_id_str": "1889752489064378392",
+                                                                        "display_text_range": [
+                                                                            15,
+                                                                            51
+                                                                        ],
+                                                                        "entities": {
+                                                                            "hashtags": [],
+                                                                            "symbols": [],
+                                                                            "timestamps": [],
+                                                                            "urls": [],
+                                                                            "user_mentions": [
+                                                                                {
+                                                                                    "id_str": "1769426369526771712",
+                                                                                    "name": "nexamind",
+                                                                                    "screen_name": "nexamind91326",
+                                                                                    "indices": [
+                                                                                        0,
+                                                                                        14
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "favorite_count": 0,
+                                                                        "favorited": false,
+                                                                        "full_text": "@nexamind91326 Transformative art, powered by bytes",
+                                                                        "in_reply_to_screen_name": "nexamind91326",
+                                                                        "in_reply_to_status_id_str": "1889755100664692853",
+                                                                        "in_reply_to_user_id_str": "1769426369526771712",
+                                                                        "is_quote_status": false,
+                                                                        "lang": "en",
+                                                                        "quote_count": 0,
+                                                                        "reply_count": 0,
+                                                                        "retweet_count": 0,
+                                                                        "retweeted": false,
+                                                                        "user_id_str": "1769424777998180352",
+                                                                        "id_str": "1889757822608712180"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "tweetDisplayType": "Tweet"
+                                                        },
+                                                        "clientEventInfo": {
+                                                            "component": "tweet",
+                                                            "element": "tweet",
+                                                            "details": {
+                                                                "timelinesDetails": {
+                                                                    "injectionType": "RankedOrganicTweet",
+                                                                    "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "metadata": {
+                                                "conversationMetadata": {
+                                                    "allTweetIds": [
+                                                        "1889752489064378392",
+                                                        "1889755100664692853",
+                                                        "1889757822608712180"
+                                                    ],
+                                                    "enableDeduplication": true
+                                                }
+                                            },
+                                            "displayType": "VerticalConversation",
+                                            "clientEventInfo": {
+                                                "component": "suggest_ranked_organic_tweet",
+                                                "details": {
+                                                    "timelinesDetails": {
+                                                        "injectionType": "RankedOrganicTweet",
+                                                        "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "entryId": "tweet-1889750014450421779",
+                                        "sortIndex": "1908263658341793782",
+                                        "content": {
+                                            "entryType": "TimelineTimelineItem",
+                                            "__typename": "TimelineTimelineItem",
+                                            "itemContent": {
+                                                "itemType": "TimelineTweet",
+                                                "__typename": "TimelineTweet",
+                                                "tweet_results": {
+                                                    "result": {
+                                                        "__typename": "Tweet",
+                                                        "rest_id": "1889750014450421779",
+                                                        "core": {
+                                                            "user_results": {
+                                                                "result": {
+                                                                    "__typename": "User",
+                                                                    "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                    "rest_id": "1769424777998180352",
+                                                                    "affiliates_highlighted_label": {},
+                                                                    "has_graduated_access": false,
+                                                                    "parody_commentary_fan_label": "None",
+                                                                    "is_blue_verified": false,
+                                                                    "profile_image_shape": "Circle",
+                                                                    "legacy": {
+                                                                        "following": false,
+                                                                        "can_dm": true,
+                                                                        "can_media_tag": true,
+                                                                        "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                        "default_profile": true,
+                                                                        "default_profile_image": false,
+                                                                        "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                        "entities": {
+                                                                            "description": {
+                                                                                "urls": []
+                                                                            }
+                                                                        },
+                                                                        "fast_followers_count": 0,
+                                                                        "favourites_count": 124,
+                                                                        "followers_count": 0,
+                                                                        "friends_count": 0,
+                                                                        "has_custom_timelines": false,
+                                                                        "is_translator": false,
+                                                                        "listed_count": 0,
+                                                                        "location": "",
+                                                                        "media_count": 0,
+                                                                        "name": "aurorabyte",
+                                                                        "needs_phone_verification": false,
+                                                                        "normal_followers_count": 0,
+                                                                        "pinned_tweet_ids_str": [],
+                                                                        "possibly_sensitive": false,
+                                                                        "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                        "profile_interstitial_type": "",
+                                                                        "screen_name": "aurorabyte79324",
+                                                                        "statuses_count": 355,
+                                                                        "translator_type": "none",
+                                                                        "verified": false,
+                                                                        "want_retweets": false,
+                                                                        "withheld_in_countries": []
+                                                                    },
+                                                                    "tipjar_settings": {}
+                                                                }
+                                                            }
+                                                        },
+                                                        "unmention_data": {},
+                                                        "edit_control": {
+                                                            "edit_tweet_ids": [
+                                                                "1889750014450421779"
+                                                            ],
+                                                            "editable_until_msecs": "1739390087959",
+                                                            "is_edit_eligible": false,
+                                                            "edits_remaining": "5"
+                                                        },
+                                                        "is_translatable": false,
+                                                        "views": {
+                                                            "state": "Enabled"
+                                                        },
+                                                        "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                        "grok_analysis_button": true,
+                                                        "legacy": {
+                                                            "bookmark_count": 0,
+                                                            "bookmarked": false,
+                                                            "created_at": "Wed Feb 12 18:54:47 +0000 2025",
+                                                            "conversation_id_str": "1889750014450421779",
+                                                            "display_text_range": [
+                                                                0,
+                                                                29
+                                                            ],
+                                                            "entities": {
+                                                                "hashtags": [],
+                                                                "symbols": [],
+                                                                "timestamps": [],
+                                                                "urls": [],
+                                                                "user_mentions": [
+                                                                    {
+                                                                        "id_str": "44196397",
+                                                                        "name": "Elon Musk",
+                                                                        "screen_name": "elonmusk",
+                                                                        "indices": [
+                                                                            3,
+                                                                            12
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "favorite_count": 0,
+                                                            "favorited": false,
+                                                            "full_text": "RT @elonmusk: What a scammer!",
+                                                            "is_quote_status": true,
+                                                            "lang": "en",
+                                                            "quote_count": 0,
+                                                            "quoted_status_id_str": "1889727512361480553",
+                                                            "quoted_status_permalink": {
+                                                                "url": "https://t.co/ovUnyPtYgv",
+                                                                "expanded": "https://twitter.com/amuse/status/1889727512361480553",
+                                                                "display": "x.com/amuse/status/1…"
+                                                            },
+                                                            "reply_count": 0,
+                                                            "retweet_count": 26163,
+                                                            "retweeted": true,
+                                                            "user_id_str": "1769424777998180352",
+                                                            "id_str": "1889750014450421779",
+                                                            "retweeted_status_result": {
+                                                                "result": {
+                                                                    "__typename": "Tweet",
+                                                                    "rest_id": "1889732209315095019",
+                                                                    "core": {
+                                                                        "user_results": {
+                                                                            "result": {
+                                                                                "__typename": "User",
+                                                                                "id": "VXNlcjo0NDE5NjM5Nw==",
+                                                                                "rest_id": "44196397",
+                                                                                "affiliates_highlighted_label": {
+                                                                                    "label": {
+                                                                                        "url": {
+                                                                                            "url": "https://twitter.com/X",
+                                                                                            "urlType": "DeepLink"
+                                                                                        },
+                                                                                        "badge": {
+                                                                                            "url": "https://pbs.twimg.com/profile_images/1683899100922511378/5lY42eHs_bigger.jpg"
+                                                                                        },
+                                                                                        "description": "X",
+                                                                                        "userLabelType": "BusinessLabel",
+                                                                                        "userLabelDisplayType": "Badge"
+                                                                                    }
+                                                                                },
+                                                                                "has_graduated_access": true,
+                                                                                "parody_commentary_fan_label": "None",
+                                                                                "is_blue_verified": true,
+                                                                                "profile_image_shape": "Circle",
+                                                                                "legacy": {
+                                                                                    "following": false,
+                                                                                    "can_dm": false,
+                                                                                    "can_media_tag": false,
+                                                                                    "created_at": "Tue Jun 02 20:12:29 +0000 2009",
+                                                                                    "default_profile": false,
+                                                                                    "default_profile_image": false,
+                                                                                    "description": "",
+                                                                                    "entities": {
+                                                                                        "description": {
+                                                                                            "urls": []
+                                                                                        }
+                                                                                    },
+                                                                                    "fast_followers_count": 0,
+                                                                                    "favourites_count": 139624,
+                                                                                    "followers_count": 218701925,
+                                                                                    "friends_count": 1102,
+                                                                                    "has_custom_timelines": true,
+                                                                                    "is_translator": false,
+                                                                                    "listed_count": 161717,
+                                                                                    "location": "",
+                                                                                    "media_count": 3750,
+                                                                                    "name": "Elon Musk",
+                                                                                    "normal_followers_count": 218701925,
+                                                                                    "pinned_tweet_ids_str": [
+                                                                                        "1908025106795823436"
+                                                                                    ],
+                                                                                    "possibly_sensitive": false,
+                                                                                    "profile_banner_url": "https://pbs.twimg.com/profile_banners/44196397/1739948056",
+                                                                                    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1893803697185910784/Na5lOWi5_normal.jpg",
+                                                                                    "profile_interstitial_type": "",
+                                                                                    "screen_name": "elonmusk",
+                                                                                    "statuses_count": 76433,
+                                                                                    "translator_type": "none",
+                                                                                    "verified": false,
+                                                                                    "want_retweets": false,
+                                                                                    "withheld_in_countries": []
+                                                                                },
+                                                                                "professional": {
+                                                                                    "rest_id": "1679729435447275522",
+                                                                                    "professional_type": "Creator",
+                                                                                    "category": []
+                                                                                },
+                                                                                "tipjar_settings": {
+                                                                                    "is_enabled": false
+                                                                                },
+                                                                                "super_follow_eligible": true
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "unmention_data": {},
+                                                                    "edit_control": {
+                                                                        "edit_tweet_ids": [
+                                                                            "1889732209315095019"
+                                                                        ],
+                                                                        "editable_until_msecs": "1739385842000",
+                                                                        "is_edit_eligible": true,
+                                                                        "edits_remaining": "5"
+                                                                    },
+                                                                    "is_translatable": false,
+                                                                    "views": {
+                                                                        "count": "7371547",
+                                                                        "state": "EnabledWithCount"
+                                                                    },
+                                                                    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                                                                    "grok_analysis_button": true,
+                                                                    "quoted_status_result": {
+                                                                        "result": {
+                                                                            "__typename": "Tweet",
+                                                                            "rest_id": "1889727512361480553",
+                                                                            "core": {
+                                                                                "user_results": {
+                                                                                    "result": {
+                                                                                        "__typename": "User",
+                                                                                        "id": "VXNlcjo0MjM5NTUx",
+                                                                                        "rest_id": "4239551",
+                                                                                        "affiliates_highlighted_label": {},
+                                                                                        "has_graduated_access": true,
+                                                                                        "parody_commentary_fan_label": "None",
+                                                                                        "is_blue_verified": true,
+                                                                                        "profile_image_shape": "Circle",
+                                                                                        "legacy": {
+                                                                                            "following": false,
+                                                                                            "can_dm": false,
+                                                                                            "can_media_tag": false,
+                                                                                            "created_at": "Wed Apr 11 20:34:15 +0000 2007",
+                                                                                            "default_profile": false,
+                                                                                            "default_profile_image": false,
+                                                                                            "description": "Conservative Headlines & Articles. Subscribe to DM.",
+                                                                                            "entities": {
+                                                                                                "description": {
+                                                                                                    "urls": []
+                                                                                                },
+                                                                                                "url": {
+                                                                                                    "urls": [
+                                                                                                        {
+                                                                                                            "display_url": "amuse.bio.link",
+                                                                                                            "expanded_url": "http://amuse.bio.link",
+                                                                                                            "url": "https://t.co/jrZDYUGMlY",
+                                                                                                            "indices": [
+                                                                                                                0,
+                                                                                                                23
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            },
+                                                                                            "fast_followers_count": 0,
+                                                                                            "favourites_count": 268467,
+                                                                                            "followers_count": 607563,
+                                                                                            "friends_count": 489,
+                                                                                            "has_custom_timelines": true,
+                                                                                            "is_translator": false,
+                                                                                            "listed_count": 3197,
+                                                                                            "location": "United States of America",
+                                                                                            "media_count": 34486,
+                                                                                            "name": "@amuse",
+                                                                                            "normal_followers_count": 607563,
+                                                                                            "pinned_tweet_ids_str": [],
+                                                                                            "possibly_sensitive": false,
+                                                                                            "profile_banner_url": "https://pbs.twimg.com/profile_banners/4239551/1743784684",
+                                                                                            "profile_image_url_https": "https://pbs.twimg.com/profile_images/1880789348557168640/QJHxtJWI_normal.jpg",
+                                                                                            "profile_interstitial_type": "",
+                                                                                            "screen_name": "amuse",
+                                                                                            "statuses_count": 77844,
+                                                                                            "translator_type": "none",
+                                                                                            "url": "https://t.co/jrZDYUGMlY",
+                                                                                            "verified": false,
+                                                                                            "want_retweets": false,
+                                                                                            "withheld_in_countries": []
+                                                                                        },
+                                                                                        "professional": {
+                                                                                            "rest_id": "1595393568474120194",
+                                                                                            "professional_type": "Business",
+                                                                                            "category": []
+                                                                                        },
+                                                                                        "tipjar_settings": {
+                                                                                            "is_enabled": true,
+                                                                                            "venmo_handle": "therealamuse"
+                                                                                        },
+                                                                                        "super_follow_eligible": true
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "unmention_data": {},
+                                                                            "edit_control": {
+                                                                                "edit_tweet_ids": [
+                                                                                    "1889727512361480553"
+                                                                                ],
+                                                                                "editable_until_msecs": "1739384723000",
+                                                                                "is_edit_eligible": false,
+                                                                                "edits_remaining": "5"
+                                                                            },
+                                                                            "is_translatable": false,
+                                                                            "views": {
+                                                                                "count": "7640762",
+                                                                                "state": "EnabledWithCount"
+                                                                            },
+                                                                            "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                                            "note_tweet": {
+                                                                                "is_expandable": true,
+                                                                                "note_tweet_results": {
+                                                                                    "result": {
+                                                                                        "id": "Tm90ZVR3ZWV0OjE4ODk3Mjc1MTIyMzk4MzcxODQ=",
+                                                                                        "text": "LAWFARE: Before Judge McConnell ordered Trump to restore USAID funding and called him a tyrant he was accused of buying his lifetime judicial appointment. He spent over $700K contributing to Democrats and funneled thousands to his state's two senators who recommended his appointment to Obama. They refused to recuse themselves from his confirmation vote. \n\nh/t @SteveGuest",
+                                                                                        "entity_set": {
+                                                                                            "hashtags": [],
+                                                                                            "symbols": [],
+                                                                                            "urls": [],
+                                                                                            "user_mentions": [
+                                                                                                {
+                                                                                                    "id_str": "341194704",
+                                                                                                    "name": "Steve Guest",
+                                                                                                    "screen_name": "SteveGuest",
+                                                                                                    "indices": [
+                                                                                                        362,
+                                                                                                        373
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "richtext": {
+                                                                                            "richtext_tags": [
+                                                                                                {
+                                                                                                    "from_index": 0,
+                                                                                                    "to_index": 8,
+                                                                                                    "richtext_types": [
+                                                                                                        "Bold"
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "media": {
+                                                                                            "inline_media": []
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "grok_analysis_button": true,
+                                                                            "legacy": {
+                                                                                "bookmark_count": 816,
+                                                                                "bookmarked": false,
+                                                                                "created_at": "Wed Feb 12 17:25:23 +0000 2025",
+                                                                                "conversation_id_str": "1889727512361480553",
+                                                                                "display_text_range": [
+                                                                                    0,
+                                                                                    271
+                                                                                ],
+                                                                                "entities": {
+                                                                                    "hashtags": [],
+                                                                                    "media": [
+                                                                                        {
+                                                                                            "display_url": "pic.x.com/t4bfzgRF0L",
+                                                                                            "expanded_url": "https://x.com/amuse/status/1889727512361480553/photo/1",
+                                                                                            "ext_alt_text": "Before Rhode Island Judge Jack McConnell called President Trump a ‘tyrant’ in 2021, he funneled $700,000 to Democrats including thousands to Senators Reed and Whitehouse  who recommended his lifetime judicial appointment to Obama and and both refused to recuse themselves from the confirmation vote.",
+                                                                                            "id_str": "1889727374066884608",
+                                                                                            "indices": [
+                                                                                                272,
+                                                                                                295
+                                                                                            ],
+                                                                                            "media_key": "3_1889727374066884608",
+                                                                                            "media_url_https": "https://pbs.twimg.com/media/GjmpCNWWoAACQjQ.jpg",
+                                                                                            "type": "photo",
+                                                                                            "url": "https://t.co/t4bfzgRF0L",
+                                                                                            "ext_media_availability": {
+                                                                                                "status": "Available"
+                                                                                            },
+                                                                                            "features": {
+                                                                                                "large": {
+                                                                                                    "faces": [
+                                                                                                        {
+                                                                                                            "x": 1817,
+                                                                                                            "y": 825,
+                                                                                                            "h": 113,
+                                                                                                            "w": 113
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 1855,
+                                                                                                            "y": 249,
+                                                                                                            "h": 97,
+                                                                                                            "w": 97
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 483,
+                                                                                                            "y": 1647,
+                                                                                                            "h": 179,
+                                                                                                            "w": 179
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 1501,
+                                                                                                            "y": 349,
+                                                                                                            "h": 291,
+                                                                                                            "w": 291
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 925,
+                                                                                                            "y": 355,
+                                                                                                            "h": 439,
+                                                                                                            "w": 439
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 545,
+                                                                                                            "y": 425,
+                                                                                                            "h": 457,
+                                                                                                            "w": 457
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                "medium": {
+                                                                                                    "faces": [
+                                                                                                        {
+                                                                                                            "x": 1064,
+                                                                                                            "y": 483,
+                                                                                                            "h": 66,
+                                                                                                            "w": 66
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 1087,
+                                                                                                            "y": 146,
+                                                                                                            "h": 57,
+                                                                                                            "w": 57
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 283,
+                                                                                                            "y": 965,
+                                                                                                            "h": 105,
+                                                                                                            "w": 105
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 880,
+                                                                                                            "y": 204,
+                                                                                                            "h": 170,
+                                                                                                            "w": 170
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 542,
+                                                                                                            "y": 208,
+                                                                                                            "h": 257,
+                                                                                                            "w": 257
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 319,
+                                                                                                            "y": 249,
+                                                                                                            "h": 268,
+                                                                                                            "w": 268
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                "small": {
+                                                                                                    "faces": [
+                                                                                                        {
+                                                                                                            "x": 603,
+                                                                                                            "y": 274,
+                                                                                                            "h": 37,
+                                                                                                            "w": 37
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 616,
+                                                                                                            "y": 82,
+                                                                                                            "h": 32,
+                                                                                                            "w": 32
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 160,
+                                                                                                            "y": 547,
+                                                                                                            "h": 59,
+                                                                                                            "w": 59
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 498,
+                                                                                                            "y": 116,
+                                                                                                            "h": 96,
+                                                                                                            "w": 96
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 307,
+                                                                                                            "y": 118,
+                                                                                                            "h": 145,
+                                                                                                            "w": 145
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 181,
+                                                                                                            "y": 141,
+                                                                                                            "h": 151,
+                                                                                                            "w": 151
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                "orig": {
+                                                                                                    "faces": [
+                                                                                                        {
+                                                                                                            "x": 3328,
+                                                                                                            "y": 1512,
+                                                                                                            "h": 208,
+                                                                                                            "w": 208
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 3398,
+                                                                                                            "y": 457,
+                                                                                                            "h": 179,
+                                                                                                            "w": 179
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 886,
+                                                                                                            "y": 3017,
+                                                                                                            "h": 329,
+                                                                                                            "w": 329
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 2750,
+                                                                                                            "y": 640,
+                                                                                                            "h": 534,
+                                                                                                            "w": 534
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 1695,
+                                                                                                            "y": 651,
+                                                                                                            "h": 805,
+                                                                                                            "w": 805
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 999,
+                                                                                                            "y": 780,
+                                                                                                            "h": 838,
+                                                                                                            "w": 838
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            },
+                                                                                            "sizes": {
+                                                                                                "large": {
+                                                                                                    "h": 2005,
+                                                                                                    "w": 2048,
+                                                                                                    "resize": "fit"
+                                                                                                },
+                                                                                                "medium": {
+                                                                                                    "h": 1175,
+                                                                                                    "w": 1200,
+                                                                                                    "resize": "fit"
+                                                                                                },
+                                                                                                "small": {
+                                                                                                    "h": 666,
+                                                                                                    "w": 680,
+                                                                                                    "resize": "fit"
+                                                                                                },
+                                                                                                "thumb": {
+                                                                                                    "h": 150,
+                                                                                                    "w": 150,
+                                                                                                    "resize": "crop"
+                                                                                                }
+                                                                                            },
+                                                                                            "original_info": {
+                                                                                                "height": 3672,
+                                                                                                "width": 3750,
+                                                                                                "focus_rects": [
+                                                                                                    {
+                                                                                                        "x": 0,
+                                                                                                        "y": 1481,
+                                                                                                        "w": 3750,
+                                                                                                        "h": 2100
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "x": 0,
+                                                                                                        "y": 0,
+                                                                                                        "w": 3672,
+                                                                                                        "h": 3672
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "x": 0,
+                                                                                                        "y": 0,
+                                                                                                        "w": 3221,
+                                                                                                        "h": 3672
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "x": 0,
+                                                                                                        "y": 0,
+                                                                                                        "w": 1836,
+                                                                                                        "h": 3672
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "x": 0,
+                                                                                                        "y": 0,
+                                                                                                        "w": 3750,
+                                                                                                        "h": 3672
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "allow_download_status": {
+                                                                                                "allow_download": true
+                                                                                            },
+                                                                                            "media_results": {
+                                                                                                "result": {
+                                                                                                    "media_key": "3_1889727374066884608"
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    ],
+                                                                                    "symbols": [],
+                                                                                    "timestamps": [],
+                                                                                    "urls": [],
+                                                                                    "user_mentions": []
+                                                                                },
+                                                                                "extended_entities": {
+                                                                                    "media": [
+                                                                                        {
+                                                                                            "display_url": "pic.x.com/t4bfzgRF0L",
+                                                                                            "expanded_url": "https://x.com/amuse/status/1889727512361480553/photo/1",
+                                                                                            "ext_alt_text": "Before Rhode Island Judge Jack McConnell called President Trump a ‘tyrant’ in 2021, he funneled $700,000 to Democrats including thousands to Senators Reed and Whitehouse  who recommended his lifetime judicial appointment to Obama and and both refused to recuse themselves from the confirmation vote.",
+                                                                                            "id_str": "1889727374066884608",
+                                                                                            "indices": [
+                                                                                                272,
+                                                                                                295
+                                                                                            ],
+                                                                                            "media_key": "3_1889727374066884608",
+                                                                                            "media_url_https": "https://pbs.twimg.com/media/GjmpCNWWoAACQjQ.jpg",
+                                                                                            "type": "photo",
+                                                                                            "url": "https://t.co/t4bfzgRF0L",
+                                                                                            "ext_media_availability": {
+                                                                                                "status": "Available"
+                                                                                            },
+                                                                                            "features": {
+                                                                                                "large": {
+                                                                                                    "faces": [
+                                                                                                        {
+                                                                                                            "x": 1817,
+                                                                                                            "y": 825,
+                                                                                                            "h": 113,
+                                                                                                            "w": 113
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 1855,
+                                                                                                            "y": 249,
+                                                                                                            "h": 97,
+                                                                                                            "w": 97
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 483,
+                                                                                                            "y": 1647,
+                                                                                                            "h": 179,
+                                                                                                            "w": 179
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 1501,
+                                                                                                            "y": 349,
+                                                                                                            "h": 291,
+                                                                                                            "w": 291
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 925,
+                                                                                                            "y": 355,
+                                                                                                            "h": 439,
+                                                                                                            "w": 439
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 545,
+                                                                                                            "y": 425,
+                                                                                                            "h": 457,
+                                                                                                            "w": 457
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                "medium": {
+                                                                                                    "faces": [
+                                                                                                        {
+                                                                                                            "x": 1064,
+                                                                                                            "y": 483,
+                                                                                                            "h": 66,
+                                                                                                            "w": 66
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 1087,
+                                                                                                            "y": 146,
+                                                                                                            "h": 57,
+                                                                                                            "w": 57
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 283,
+                                                                                                            "y": 965,
+                                                                                                            "h": 105,
+                                                                                                            "w": 105
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 880,
+                                                                                                            "y": 204,
+                                                                                                            "h": 170,
+                                                                                                            "w": 170
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 542,
+                                                                                                            "y": 208,
+                                                                                                            "h": 257,
+                                                                                                            "w": 257
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 319,
+                                                                                                            "y": 249,
+                                                                                                            "h": 268,
+                                                                                                            "w": 268
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                "small": {
+                                                                                                    "faces": [
+                                                                                                        {
+                                                                                                            "x": 603,
+                                                                                                            "y": 274,
+                                                                                                            "h": 37,
+                                                                                                            "w": 37
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 616,
+                                                                                                            "y": 82,
+                                                                                                            "h": 32,
+                                                                                                            "w": 32
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 160,
+                                                                                                            "y": 547,
+                                                                                                            "h": 59,
+                                                                                                            "w": 59
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 498,
+                                                                                                            "y": 116,
+                                                                                                            "h": 96,
+                                                                                                            "w": 96
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 307,
+                                                                                                            "y": 118,
+                                                                                                            "h": 145,
+                                                                                                            "w": 145
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 181,
+                                                                                                            "y": 141,
+                                                                                                            "h": 151,
+                                                                                                            "w": 151
+                                                                                                        }
+                                                                                                    ]
+                                                                                                },
+                                                                                                "orig": {
+                                                                                                    "faces": [
+                                                                                                        {
+                                                                                                            "x": 3328,
+                                                                                                            "y": 1512,
+                                                                                                            "h": 208,
+                                                                                                            "w": 208
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 3398,
+                                                                                                            "y": 457,
+                                                                                                            "h": 179,
+                                                                                                            "w": 179
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 886,
+                                                                                                            "y": 3017,
+                                                                                                            "h": 329,
+                                                                                                            "w": 329
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 2750,
+                                                                                                            "y": 640,
+                                                                                                            "h": 534,
+                                                                                                            "w": 534
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 1695,
+                                                                                                            "y": 651,
+                                                                                                            "h": 805,
+                                                                                                            "w": 805
+                                                                                                        },
+                                                                                                        {
+                                                                                                            "x": 999,
+                                                                                                            "y": 780,
+                                                                                                            "h": 838,
+                                                                                                            "w": 838
+                                                                                                        }
+                                                                                                    ]
+                                                                                                }
+                                                                                            },
+                                                                                            "sizes": {
+                                                                                                "large": {
+                                                                                                    "h": 2005,
+                                                                                                    "w": 2048,
+                                                                                                    "resize": "fit"
+                                                                                                },
+                                                                                                "medium": {
+                                                                                                    "h": 1175,
+                                                                                                    "w": 1200,
+                                                                                                    "resize": "fit"
+                                                                                                },
+                                                                                                "small": {
+                                                                                                    "h": 666,
+                                                                                                    "w": 680,
+                                                                                                    "resize": "fit"
+                                                                                                },
+                                                                                                "thumb": {
+                                                                                                    "h": 150,
+                                                                                                    "w": 150,
+                                                                                                    "resize": "crop"
+                                                                                                }
+                                                                                            },
+                                                                                            "original_info": {
+                                                                                                "height": 3672,
+                                                                                                "width": 3750,
+                                                                                                "focus_rects": [
+                                                                                                    {
+                                                                                                        "x": 0,
+                                                                                                        "y": 1481,
+                                                                                                        "w": 3750,
+                                                                                                        "h": 2100
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "x": 0,
+                                                                                                        "y": 0,
+                                                                                                        "w": 3672,
+                                                                                                        "h": 3672
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "x": 0,
+                                                                                                        "y": 0,
+                                                                                                        "w": 3221,
+                                                                                                        "h": 3672
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "x": 0,
+                                                                                                        "y": 0,
+                                                                                                        "w": 1836,
+                                                                                                        "h": 3672
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "x": 0,
+                                                                                                        "y": 0,
+                                                                                                        "w": 3750,
+                                                                                                        "h": 3672
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "allow_download_status": {
+                                                                                                "allow_download": true
+                                                                                            },
+                                                                                            "media_results": {
+                                                                                                "result": {
+                                                                                                    "media_key": "3_1889727374066884608"
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "favorite_count": 18546,
+                                                                                "favorited": false,
+                                                                                "full_text": "LAWFARE: Before Judge McConnell ordered Trump to restore USAID funding and called him a tyrant he was accused of buying his lifetime judicial appointment. He spent over $700K contributing to Democrats and funneled thousands to his state's two senators who recommended his https://t.co/t4bfzgRF0L",
+                                                                                "is_quote_status": false,
+                                                                                "lang": "en",
+                                                                                "possibly_sensitive": false,
+                                                                                "possibly_sensitive_editable": true,
+                                                                                "quote_count": 515,
+                                                                                "reply_count": 1361,
+                                                                                "retweet_count": 7650,
+                                                                                "retweeted": false,
+                                                                                "user_id_str": "4239551",
+                                                                                "id_str": "1889727512361480553"
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "legacy": {
+                                                                        "bookmark_count": 1551,
+                                                                        "bookmarked": false,
+                                                                        "created_at": "Wed Feb 12 17:44:02 +0000 2025",
+                                                                        "conversation_id_str": "1889732209315095019",
+                                                                        "display_text_range": [
+                                                                            0,
+                                                                            15
+                                                                        ],
+                                                                        "entities": {
+                                                                            "hashtags": [],
+                                                                            "symbols": [],
+                                                                            "timestamps": [],
+                                                                            "urls": [],
+                                                                            "user_mentions": []
+                                                                        },
+                                                                        "favorite_count": 88844,
+                                                                        "favorited": false,
+                                                                        "full_text": "What a scammer!",
+                                                                        "is_quote_status": true,
+                                                                        "lang": "en",
+                                                                        "quote_count": 635,
+                                                                        "quoted_status_id_str": "1889727512361480553",
+                                                                        "quoted_status_permalink": {
+                                                                            "url": "https://t.co/ovUnyPtYgv",
+                                                                            "expanded": "https://twitter.com/amuse/status/1889727512361480553",
+                                                                            "display": "x.com/amuse/status/1…"
+                                                                        },
+                                                                        "reply_count": 5595,
+                                                                        "retweet_count": 26163,
+                                                                        "retweeted": true,
+                                                                        "user_id_str": "44196397",
+                                                                        "id_str": "1889732209315095019"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "tweetDisplayType": "Tweet"
+                                            },
+                                            "clientEventInfo": {
+                                                "component": "tweet",
+                                                "element": "tweet",
+                                                "details": {
+                                                    "timelinesDetails": {
+                                                        "injectionType": "RankedOrganicTweet",
+                                                        "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "entryId": "tweet-1889744826393849932",
+                                        "sortIndex": "1908263658341793781",
+                                        "content": {
+                                            "entryType": "TimelineTimelineItem",
+                                            "__typename": "TimelineTimelineItem",
+                                            "itemContent": {
+                                                "itemType": "TimelineTweet",
+                                                "__typename": "TimelineTweet",
+                                                "tweet_results": {
+                                                    "result": {
+                                                        "__typename": "Tweet",
+                                                        "rest_id": "1889744826393849932",
+                                                        "core": {
+                                                            "user_results": {
+                                                                "result": {
+                                                                    "__typename": "User",
+                                                                    "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                    "rest_id": "1769424777998180352",
+                                                                    "affiliates_highlighted_label": {},
+                                                                    "has_graduated_access": false,
+                                                                    "parody_commentary_fan_label": "None",
+                                                                    "is_blue_verified": false,
+                                                                    "profile_image_shape": "Circle",
+                                                                    "legacy": {
+                                                                        "following": false,
+                                                                        "can_dm": true,
+                                                                        "can_media_tag": true,
+                                                                        "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                        "default_profile": true,
+                                                                        "default_profile_image": false,
+                                                                        "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                        "entities": {
+                                                                            "description": {
+                                                                                "urls": []
+                                                                            }
+                                                                        },
+                                                                        "fast_followers_count": 0,
+                                                                        "favourites_count": 124,
+                                                                        "followers_count": 0,
+                                                                        "friends_count": 0,
+                                                                        "has_custom_timelines": false,
+                                                                        "is_translator": false,
+                                                                        "listed_count": 0,
+                                                                        "location": "",
+                                                                        "media_count": 0,
+                                                                        "name": "aurorabyte",
+                                                                        "needs_phone_verification": false,
+                                                                        "normal_followers_count": 0,
+                                                                        "pinned_tweet_ids_str": [],
+                                                                        "possibly_sensitive": false,
+                                                                        "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                        "profile_interstitial_type": "",
+                                                                        "screen_name": "aurorabyte79324",
+                                                                        "statuses_count": 355,
+                                                                        "translator_type": "none",
+                                                                        "verified": false,
+                                                                        "want_retweets": false,
+                                                                        "withheld_in_countries": []
+                                                                    },
+                                                                    "tipjar_settings": {}
+                                                                }
+                                                            }
+                                                        },
+                                                        "unmention_data": {},
+                                                        "edit_control": {
+                                                            "edit_tweet_ids": [
+                                                                "1889744826393849932"
+                                                            ],
+                                                            "editable_until_msecs": "1739388851030",
+                                                            "is_edit_eligible": false,
+                                                            "edits_remaining": "5"
+                                                        },
+                                                        "is_translatable": false,
+                                                        "views": {
+                                                            "state": "Enabled"
+                                                        },
+                                                        "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                        "grok_analysis_button": true,
+                                                        "legacy": {
+                                                            "bookmark_count": 0,
+                                                            "bookmarked": false,
+                                                            "created_at": "Wed Feb 12 18:34:11 +0000 2025",
+                                                            "conversation_id_str": "1889744826393849932",
+                                                            "display_text_range": [
+                                                                0,
+                                                                140
+                                                            ],
+                                                            "entities": {
+                                                                "hashtags": [],
+                                                                "symbols": [],
+                                                                "timestamps": [],
+                                                                "urls": [],
+                                                                "user_mentions": [
+                                                                    {
+                                                                        "id_str": "292929271",
+                                                                        "name": "Charlie Kirk",
+                                                                        "screen_name": "charliekirk11",
+                                                                        "indices": [
+                                                                            3,
+                                                                            17
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "favorite_count": 0,
+                                                            "favorited": false,
+                                                            "full_text": "RT @charliekirk11: BREAKING: A federal judge has ruled that President Trump does in fact have constitutional authority to freeze or limit c…",
+                                                            "is_quote_status": false,
+                                                            "lang": "en",
+                                                            "quote_count": 0,
+                                                            "reply_count": 0,
+                                                            "retweet_count": 19601,
+                                                            "retweeted": true,
+                                                            "user_id_str": "1769424777998180352",
+                                                            "id_str": "1889744826393849932",
+                                                            "retweeted_status_result": {
+                                                                "result": {
+                                                                    "__typename": "Tweet",
+                                                                    "rest_id": "1889727599800140182",
+                                                                    "core": {
+                                                                        "user_results": {
+                                                                            "result": {
+                                                                                "__typename": "User",
+                                                                                "id": "VXNlcjoyOTI5MjkyNzE=",
+                                                                                "rest_id": "292929271",
+                                                                                "affiliates_highlighted_label": {
+                                                                                    "label": {
+                                                                                        "url": {
+                                                                                            "url": "https://twitter.com/TPUSA",
+                                                                                            "urlType": "DeepLink"
+                                                                                        },
+                                                                                        "badge": {
+                                                                                            "url": "https://pbs.twimg.com/profile_images/1870964730224877568/1oaBEqYE_bigger.jpg"
+                                                                                        },
+                                                                                        "description": "Turning Point USA",
+                                                                                        "userLabelType": "BusinessLabel",
+                                                                                        "userLabelDisplayType": "Badge"
+                                                                                    }
+                                                                                },
+                                                                                "has_graduated_access": true,
+                                                                                "parody_commentary_fan_label": "None",
+                                                                                "is_blue_verified": true,
+                                                                                "profile_image_shape": "Circle",
+                                                                                "legacy": {
+                                                                                    "following": false,
+                                                                                    "can_dm": true,
+                                                                                    "can_media_tag": false,
+                                                                                    "created_at": "Wed May 04 13:37:25 +0000 2011",
+                                                                                    "default_profile": true,
+                                                                                    "default_profile_image": false,
+                                                                                    "description": "Founder & CEO: @TPUSA + @TPAction_ • Host: The Charlie Kirk Show • Click the link below to subscribe \uD83C\uDDFA\uD83C\uDDF8",
+                                                                                    "entities": {
+                                                                                        "description": {
+                                                                                            "urls": []
+                                                                                        },
+                                                                                        "url": {
+                                                                                            "urls": [
+                                                                                                {
+                                                                                                    "display_url": "podcasts.apple.com/us/podcast/the…",
+                                                                                                    "expanded_url": "https://podcasts.apple.com/us/podcast/the-charlie-kirk-show/id1460600818",
+                                                                                                    "url": "https://t.co/qiKLOzdk76",
+                                                                                                    "indices": [
+                                                                                                        0,
+                                                                                                        23
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "fast_followers_count": 0,
+                                                                                    "favourites_count": 36777,
+                                                                                    "followers_count": 4900163,
+                                                                                    "friends_count": 185787,
+                                                                                    "has_custom_timelines": true,
+                                                                                    "is_translator": false,
+                                                                                    "listed_count": 11138,
+                                                                                    "location": "Phoenix, AZ",
+                                                                                    "media_count": 10866,
+                                                                                    "name": "Charlie Kirk",
+                                                                                    "normal_followers_count": 4900163,
+                                                                                    "pinned_tweet_ids_str": [],
+                                                                                    "possibly_sensitive": false,
+                                                                                    "profile_banner_url": "https://pbs.twimg.com/profile_banners/292929271/1722636385",
+                                                                                    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1819144572179828740/z3ZuWW2J_normal.jpg",
+                                                                                    "profile_interstitial_type": "",
+                                                                                    "screen_name": "charliekirk11",
+                                                                                    "statuses_count": 68558,
+                                                                                    "translator_type": "none",
+                                                                                    "url": "https://t.co/qiKLOzdk76",
+                                                                                    "verified": false,
+                                                                                    "want_retweets": false,
+                                                                                    "withheld_in_countries": []
+                                                                                },
+                                                                                "tipjar_settings": {}
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "unmention_data": {},
+                                                                    "edit_control": {
+                                                                        "edit_tweet_ids": [
+                                                                            "1889727599800140182"
+                                                                        ],
+                                                                        "editable_until_msecs": "1739384743000",
+                                                                        "is_edit_eligible": true,
+                                                                        "edits_remaining": "5"
+                                                                    },
+                                                                    "is_translatable": false,
+                                                                    "views": {
+                                                                        "count": "16388365",
+                                                                        "state": "EnabledWithCount"
+                                                                    },
+                                                                    "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                                    "grok_analysis_button": true,
+                                                                    "legacy": {
+                                                                        "bookmark_count": 3668,
+                                                                        "bookmarked": false,
+                                                                        "created_at": "Wed Feb 12 17:25:43 +0000 2025",
+                                                                        "conversation_id_str": "1889727599800140182",
+                                                                        "display_text_range": [
+                                                                            0,
+                                                                            266
+                                                                        ],
+                                                                        "entities": {
+                                                                            "hashtags": [],
+                                                                            "media": [
+                                                                                {
+                                                                                    "display_url": "pic.x.com/KMfAj2E97w",
+                                                                                    "expanded_url": "https://x.com/globalbeaconn/status/1889724367350726930/video/1",
+                                                                                    "id_str": "1889724224182329344",
+                                                                                    "indices": [
+                                                                                        243,
+                                                                                        266
+                                                                                    ],
+                                                                                    "media_key": "7_1889724224182329344",
+                                                                                    "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1889724224182329344/pu/img/6Hq047RPMFtIEmxo.jpg",
+                                                                                    "source_status_id_str": "1889724367350726930",
+                                                                                    "source_user_id_str": "1810612162760671232",
+                                                                                    "type": "video",
+                                                                                    "url": "https://t.co/KMfAj2E97w",
+                                                                                    "additional_media_info": {
+                                                                                        "monetizable": false,
+                                                                                        "source_user": {
+                                                                                            "user_results": {
+                                                                                                "result": {
+                                                                                                    "__typename": "User",
+                                                                                                    "id": "VXNlcjoxODEwNjEyMTYyNzYwNjcxMjMy",
+                                                                                                    "rest_id": "1810612162760671232",
+                                                                                                    "affiliates_highlighted_label": {},
+                                                                                                    "has_graduated_access": true,
+                                                                                                    "parody_commentary_fan_label": "None",
+                                                                                                    "is_blue_verified": true,
+                                                                                                    "profile_image_shape": "Circle",
+                                                                                                    "legacy": {
+                                                                                                        "following": false,
+                                                                                                        "can_dm": true,
+                                                                                                        "can_media_tag": true,
+                                                                                                        "created_at": "Tue Jul 09 09:49:33 +0000 2024",
+                                                                                                        "default_profile": true,
+                                                                                                        "default_profile_image": false,
+                                                                                                        "description": "Open-Source Intel • Breaking News • Politics",
+                                                                                                        "entities": {
+                                                                                                            "description": {
+                                                                                                                "urls": []
+                                                                                                            },
+                                                                                                            "url": {
+                                                                                                                "urls": [
+                                                                                                                    {
+                                                                                                                        "display_url": "buymeacoffee.com/globalbeaconn",
+                                                                                                                        "expanded_url": "https://buymeacoffee.com/globalbeaconn",
+                                                                                                                        "url": "https://t.co/lMzquGOUk6",
+                                                                                                                        "indices": [
+                                                                                                                            0,
+                                                                                                                            23
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        },
+                                                                                                        "fast_followers_count": 0,
+                                                                                                        "favourites_count": 254574,
+                                                                                                        "followers_count": 6086,
+                                                                                                        "friends_count": 1941,
+                                                                                                        "has_custom_timelines": false,
+                                                                                                        "is_translator": false,
+                                                                                                        "listed_count": 35,
+                                                                                                        "location": "United States",
+                                                                                                        "media_count": 6274,
+                                                                                                        "name": "The Global Beacon",
+                                                                                                        "normal_followers_count": 6086,
+                                                                                                        "pinned_tweet_ids_str": [],
+                                                                                                        "possibly_sensitive": false,
+                                                                                                        "profile_banner_url": "https://pbs.twimg.com/profile_banners/1810612162760671232/1720521158",
+                                                                                                        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1859685656970100736/MGbi7cqd_normal.jpg",
+                                                                                                        "profile_interstitial_type": "",
+                                                                                                        "screen_name": "globalbeaconn",
+                                                                                                        "statuses_count": 13060,
+                                                                                                        "translator_type": "none",
+                                                                                                        "url": "https://t.co/lMzquGOUk6",
+                                                                                                        "verified": false,
+                                                                                                        "want_retweets": false,
+                                                                                                        "withheld_in_countries": []
+                                                                                                    },
+                                                                                                    "professional": {
+                                                                                                        "rest_id": "1810641258655936543",
+                                                                                                        "professional_type": "Business",
+                                                                                                        "category": [
+                                                                                                            {
+                                                                                                                "id": 579,
+                                                                                                                "name": "Media & News",
+                                                                                                                "icon_name": "IconBriefcaseStroke"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "tipjar_settings": {
+                                                                                                        "is_enabled": true,
+                                                                                                        "ethereum_handle": "0x6191bd79a078bfed07aee6523183f4e20271bb84"
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "ext_media_availability": {
+                                                                                        "status": "Available"
+                                                                                    },
+                                                                                    "sizes": {
+                                                                                        "large": {
+                                                                                            "h": 720,
+                                                                                            "w": 1280,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "medium": {
+                                                                                            "h": 675,
+                                                                                            "w": 1200,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "small": {
+                                                                                            "h": 383,
+                                                                                            "w": 680,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "thumb": {
+                                                                                            "h": 150,
+                                                                                            "w": 150,
+                                                                                            "resize": "crop"
+                                                                                        }
+                                                                                    },
+                                                                                    "original_info": {
+                                                                                        "height": 720,
+                                                                                        "width": 1280,
+                                                                                        "focus_rects": []
+                                                                                    },
+                                                                                    "video_info": {
+                                                                                        "aspect_ratio": [
+                                                                                            16,
+                                                                                            9
+                                                                                        ],
+                                                                                        "duration_millis": 59648,
+                                                                                        "variants": [
+                                                                                            {
+                                                                                                "content_type": "application/x-mpegURL",
+                                                                                                "url": "https://video.twimg.com/ext_tw_video/1889724224182329344/pu/pl/J5ruo7l7GjfZVwyz.m3u8?tag=12&v=e0e"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 256000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/ext_tw_video/1889724224182329344/pu/vid/avc1/480x270/NN2ITH1Pol5cqZ5J.mp4?tag=12"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 832000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/ext_tw_video/1889724224182329344/pu/vid/avc1/640x360/HPzc2FoAyLAeTxVm.mp4?tag=12"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 2176000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/ext_tw_video/1889724224182329344/pu/vid/avc1/1280x720/-sDeyo9925bMIoLR.mp4?tag=12"
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    "media_results": {
+                                                                                        "result": {
+                                                                                            "media_key": "7_1889724224182329344"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            ],
+                                                                            "symbols": [],
+                                                                            "timestamps": [],
+                                                                            "urls": [],
+                                                                            "user_mentions": []
+                                                                        },
+                                                                        "extended_entities": {
+                                                                            "media": [
+                                                                                {
+                                                                                    "display_url": "pic.x.com/KMfAj2E97w",
+                                                                                    "expanded_url": "https://x.com/globalbeaconn/status/1889724367350726930/video/1",
+                                                                                    "id_str": "1889724224182329344",
+                                                                                    "indices": [
+                                                                                        243,
+                                                                                        266
+                                                                                    ],
+                                                                                    "media_key": "7_1889724224182329344",
+                                                                                    "media_url_https": "https://pbs.twimg.com/ext_tw_video_thumb/1889724224182329344/pu/img/6Hq047RPMFtIEmxo.jpg",
+                                                                                    "source_status_id_str": "1889724367350726930",
+                                                                                    "source_user_id_str": "1810612162760671232",
+                                                                                    "type": "video",
+                                                                                    "url": "https://t.co/KMfAj2E97w",
+                                                                                    "additional_media_info": {
+                                                                                        "monetizable": false,
+                                                                                        "source_user": {
+                                                                                            "user_results": {
+                                                                                                "result": {
+                                                                                                    "__typename": "User",
+                                                                                                    "id": "VXNlcjoxODEwNjEyMTYyNzYwNjcxMjMy",
+                                                                                                    "rest_id": "1810612162760671232",
+                                                                                                    "affiliates_highlighted_label": {},
+                                                                                                    "has_graduated_access": true,
+                                                                                                    "parody_commentary_fan_label": "None",
+                                                                                                    "is_blue_verified": true,
+                                                                                                    "profile_image_shape": "Circle",
+                                                                                                    "legacy": {
+                                                                                                        "following": false,
+                                                                                                        "can_dm": true,
+                                                                                                        "can_media_tag": true,
+                                                                                                        "created_at": "Tue Jul 09 09:49:33 +0000 2024",
+                                                                                                        "default_profile": true,
+                                                                                                        "default_profile_image": false,
+                                                                                                        "description": "Open-Source Intel • Breaking News • Politics",
+                                                                                                        "entities": {
+                                                                                                            "description": {
+                                                                                                                "urls": []
+                                                                                                            },
+                                                                                                            "url": {
+                                                                                                                "urls": [
+                                                                                                                    {
+                                                                                                                        "display_url": "buymeacoffee.com/globalbeaconn",
+                                                                                                                        "expanded_url": "https://buymeacoffee.com/globalbeaconn",
+                                                                                                                        "url": "https://t.co/lMzquGOUk6",
+                                                                                                                        "indices": [
+                                                                                                                            0,
+                                                                                                                            23
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        },
+                                                                                                        "fast_followers_count": 0,
+                                                                                                        "favourites_count": 254574,
+                                                                                                        "followers_count": 6086,
+                                                                                                        "friends_count": 1941,
+                                                                                                        "has_custom_timelines": false,
+                                                                                                        "is_translator": false,
+                                                                                                        "listed_count": 35,
+                                                                                                        "location": "United States",
+                                                                                                        "media_count": 6274,
+                                                                                                        "name": "The Global Beacon",
+                                                                                                        "normal_followers_count": 6086,
+                                                                                                        "pinned_tweet_ids_str": [],
+                                                                                                        "possibly_sensitive": false,
+                                                                                                        "profile_banner_url": "https://pbs.twimg.com/profile_banners/1810612162760671232/1720521158",
+                                                                                                        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1859685656970100736/MGbi7cqd_normal.jpg",
+                                                                                                        "profile_interstitial_type": "",
+                                                                                                        "screen_name": "globalbeaconn",
+                                                                                                        "statuses_count": 13060,
+                                                                                                        "translator_type": "none",
+                                                                                                        "url": "https://t.co/lMzquGOUk6",
+                                                                                                        "verified": false,
+                                                                                                        "want_retweets": false,
+                                                                                                        "withheld_in_countries": []
+                                                                                                    },
+                                                                                                    "professional": {
+                                                                                                        "rest_id": "1810641258655936543",
+                                                                                                        "professional_type": "Business",
+                                                                                                        "category": [
+                                                                                                            {
+                                                                                                                "id": 579,
+                                                                                                                "name": "Media & News",
+                                                                                                                "icon_name": "IconBriefcaseStroke"
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    "tipjar_settings": {
+                                                                                                        "is_enabled": true,
+                                                                                                        "ethereum_handle": "0x6191bd79a078bfed07aee6523183f4e20271bb84"
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "ext_media_availability": {
+                                                                                        "status": "Available"
+                                                                                    },
+                                                                                    "sizes": {
+                                                                                        "large": {
+                                                                                            "h": 720,
+                                                                                            "w": 1280,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "medium": {
+                                                                                            "h": 675,
+                                                                                            "w": 1200,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "small": {
+                                                                                            "h": 383,
+                                                                                            "w": 680,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "thumb": {
+                                                                                            "h": 150,
+                                                                                            "w": 150,
+                                                                                            "resize": "crop"
+                                                                                        }
+                                                                                    },
+                                                                                    "original_info": {
+                                                                                        "height": 720,
+                                                                                        "width": 1280,
+                                                                                        "focus_rects": []
+                                                                                    },
+                                                                                    "video_info": {
+                                                                                        "aspect_ratio": [
+                                                                                            16,
+                                                                                            9
+                                                                                        ],
+                                                                                        "duration_millis": 59648,
+                                                                                        "variants": [
+                                                                                            {
+                                                                                                "content_type": "application/x-mpegURL",
+                                                                                                "url": "https://video.twimg.com/ext_tw_video/1889724224182329344/pu/pl/J5ruo7l7GjfZVwyz.m3u8?tag=12&v=e0e"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 256000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/ext_tw_video/1889724224182329344/pu/vid/avc1/480x270/NN2ITH1Pol5cqZ5J.mp4?tag=12"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 832000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/ext_tw_video/1889724224182329344/pu/vid/avc1/640x360/HPzc2FoAyLAeTxVm.mp4?tag=12"
+                                                                                            },
+                                                                                            {
+                                                                                                "bitrate": 2176000,
+                                                                                                "content_type": "video/mp4",
+                                                                                                "url": "https://video.twimg.com/ext_tw_video/1889724224182329344/pu/vid/avc1/1280x720/-sDeyo9925bMIoLR.mp4?tag=12"
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    "media_results": {
+                                                                                        "result": {
+                                                                                            "media_key": "7_1889724224182329344"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "favorite_count": 107489,
+                                                                        "favorited": false,
+                                                                        "full_text": "BREAKING: A federal judge has ruled that President Trump does in fact have constitutional authority to freeze or limit certain federal funding. This means the Trump White House can withhold funding without the district court's prior approval. https://t.co/KMfAj2E97w",
+                                                                        "is_quote_status": false,
+                                                                        "lang": "en",
+                                                                        "possibly_sensitive": false,
+                                                                        "possibly_sensitive_editable": true,
+                                                                        "quote_count": 1401,
+                                                                        "reply_count": 3228,
+                                                                        "retweet_count": 19601,
+                                                                        "retweeted": true,
+                                                                        "user_id_str": "292929271",
+                                                                        "id_str": "1889727599800140182"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "tweetDisplayType": "Tweet"
+                                            },
+                                            "clientEventInfo": {
+                                                "component": "tweet",
+                                                "element": "tweet",
+                                                "details": {
+                                                    "timelinesDetails": {
+                                                        "injectionType": "RankedOrganicTweet",
+                                                        "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "entryId": "tweet-1889737037189611592",
+                                        "sortIndex": "1908263658341793780",
+                                        "content": {
+                                            "entryType": "TimelineTimelineItem",
+                                            "__typename": "TimelineTimelineItem",
+                                            "itemContent": {
+                                                "itemType": "TimelineTweet",
+                                                "__typename": "TimelineTweet",
+                                                "tweet_results": {
+                                                    "result": {
+                                                        "__typename": "Tweet",
+                                                        "rest_id": "1889737037189611592",
+                                                        "core": {
+                                                            "user_results": {
+                                                                "result": {
+                                                                    "__typename": "User",
+                                                                    "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                    "rest_id": "1769424777998180352",
+                                                                    "affiliates_highlighted_label": {},
+                                                                    "has_graduated_access": false,
+                                                                    "parody_commentary_fan_label": "None",
+                                                                    "is_blue_verified": false,
+                                                                    "profile_image_shape": "Circle",
+                                                                    "legacy": {
+                                                                        "following": false,
+                                                                        "can_dm": true,
+                                                                        "can_media_tag": true,
+                                                                        "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                        "default_profile": true,
+                                                                        "default_profile_image": false,
+                                                                        "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                        "entities": {
+                                                                            "description": {
+                                                                                "urls": []
+                                                                            }
+                                                                        },
+                                                                        "fast_followers_count": 0,
+                                                                        "favourites_count": 124,
+                                                                        "followers_count": 0,
+                                                                        "friends_count": 0,
+                                                                        "has_custom_timelines": false,
+                                                                        "is_translator": false,
+                                                                        "listed_count": 0,
+                                                                        "location": "",
+                                                                        "media_count": 0,
+                                                                        "name": "aurorabyte",
+                                                                        "needs_phone_verification": false,
+                                                                        "normal_followers_count": 0,
+                                                                        "pinned_tweet_ids_str": [],
+                                                                        "possibly_sensitive": false,
+                                                                        "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                        "profile_interstitial_type": "",
+                                                                        "screen_name": "aurorabyte79324",
+                                                                        "statuses_count": 355,
+                                                                        "translator_type": "none",
+                                                                        "verified": false,
+                                                                        "want_retweets": false,
+                                                                        "withheld_in_countries": []
+                                                                    },
+                                                                    "tipjar_settings": {}
+                                                                }
+                                                            }
+                                                        },
+                                                        "unmention_data": {},
+                                                        "edit_control": {
+                                                            "edit_tweet_ids": [
+                                                                "1889737037189611592"
+                                                            ],
+                                                            "editable_until_msecs": "1739386993939",
+                                                            "is_edit_eligible": false,
+                                                            "edits_remaining": "5"
+                                                        },
+                                                        "is_translatable": false,
+                                                        "views": {
+                                                            "state": "Enabled"
+                                                        },
+                                                        "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                        "grok_analysis_button": true,
+                                                        "legacy": {
+                                                            "bookmark_count": 0,
+                                                            "bookmarked": false,
+                                                            "created_at": "Wed Feb 12 18:03:13 +0000 2025",
+                                                            "conversation_id_str": "1889737037189611592",
+                                                            "display_text_range": [
+                                                                0,
+                                                                37
+                                                            ],
+                                                            "entities": {
+                                                                "hashtags": [],
+                                                                "media": [
+                                                                    {
+                                                                        "display_url": "pic.x.com/7NzFTkFjhk",
+                                                                        "expanded_url": "https://x.com/elonmusk/status/1889722028120285217/photo/1",
+                                                                        "id_str": "1889722022625787904",
+                                                                        "indices": [
+                                                                            14,
+                                                                            37
+                                                                        ],
+                                                                        "media_key": "3_1889722022625787904",
+                                                                        "media_url_https": "https://pbs.twimg.com/media/GjmkKtrXwAAS5Vq.jpg",
+                                                                        "source_status_id_str": "1889722028120285217",
+                                                                        "source_user_id_str": "44196397",
+                                                                        "type": "photo",
+                                                                        "url": "https://t.co/7NzFTkFjhk",
+                                                                        "ext_media_availability": {
+                                                                            "status": "Available"
+                                                                        },
+                                                                        "features": {
+                                                                            "large": {
+                                                                                "faces": []
+                                                                            },
+                                                                            "medium": {
+                                                                                "faces": []
+                                                                            },
+                                                                            "small": {
+                                                                                "faces": []
+                                                                            },
+                                                                            "orig": {
+                                                                                "faces": []
+                                                                            }
+                                                                        },
+                                                                        "sizes": {
+                                                                            "large": {
+                                                                                "h": 1314,
+                                                                                "w": 908,
+                                                                                "resize": "fit"
+                                                                            },
+                                                                            "medium": {
+                                                                                "h": 1200,
+                                                                                "w": 829,
+                                                                                "resize": "fit"
+                                                                            },
+                                                                            "small": {
+                                                                                "h": 680,
+                                                                                "w": 470,
+                                                                                "resize": "fit"
+                                                                            },
+                                                                            "thumb": {
+                                                                                "h": 150,
+                                                                                "w": 150,
+                                                                                "resize": "crop"
+                                                                            }
+                                                                        },
+                                                                        "original_info": {
+                                                                            "height": 1314,
+                                                                            "width": 908,
+                                                                            "focus_rects": [
+                                                                                {
+                                                                                    "x": 0,
+                                                                                    "y": 0,
+                                                                                    "w": 908,
+                                                                                    "h": 508
+                                                                                },
+                                                                                {
+                                                                                    "x": 0,
+                                                                                    "y": 0,
+                                                                                    "w": 908,
+                                                                                    "h": 908
+                                                                                },
+                                                                                {
+                                                                                    "x": 0,
+                                                                                    "y": 0,
+                                                                                    "w": 908,
+                                                                                    "h": 1035
+                                                                                },
+                                                                                {
+                                                                                    "x": 251,
+                                                                                    "y": 0,
+                                                                                    "w": 657,
+                                                                                    "h": 1314
+                                                                                },
+                                                                                {
+                                                                                    "x": 0,
+                                                                                    "y": 0,
+                                                                                    "w": 908,
+                                                                                    "h": 1314
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "media_results": {
+                                                                            "result": {
+                                                                                "media_key": "3_1889722022625787904"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ],
+                                                                "symbols": [],
+                                                                "timestamps": [],
+                                                                "urls": [],
+                                                                "user_mentions": [
+                                                                    {
+                                                                        "id_str": "44196397",
+                                                                        "name": "Elon Musk",
+                                                                        "screen_name": "elonmusk",
+                                                                        "indices": [
+                                                                            3,
+                                                                            12
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "extended_entities": {
+                                                                "media": [
+                                                                    {
+                                                                        "display_url": "pic.x.com/7NzFTkFjhk",
+                                                                        "expanded_url": "https://x.com/elonmusk/status/1889722028120285217/photo/1",
+                                                                        "id_str": "1889722022625787904",
+                                                                        "indices": [
+                                                                            14,
+                                                                            37
+                                                                        ],
+                                                                        "media_key": "3_1889722022625787904",
+                                                                        "media_url_https": "https://pbs.twimg.com/media/GjmkKtrXwAAS5Vq.jpg",
+                                                                        "source_status_id_str": "1889722028120285217",
+                                                                        "source_user_id_str": "44196397",
+                                                                        "type": "photo",
+                                                                        "url": "https://t.co/7NzFTkFjhk",
+                                                                        "ext_media_availability": {
+                                                                            "status": "Available"
+                                                                        },
+                                                                        "features": {
+                                                                            "large": {
+                                                                                "faces": []
+                                                                            },
+                                                                            "medium": {
+                                                                                "faces": []
+                                                                            },
+                                                                            "small": {
+                                                                                "faces": []
+                                                                            },
+                                                                            "orig": {
+                                                                                "faces": []
+                                                                            }
+                                                                        },
+                                                                        "sizes": {
+                                                                            "large": {
+                                                                                "h": 1314,
+                                                                                "w": 908,
+                                                                                "resize": "fit"
+                                                                            },
+                                                                            "medium": {
+                                                                                "h": 1200,
+                                                                                "w": 829,
+                                                                                "resize": "fit"
+                                                                            },
+                                                                            "small": {
+                                                                                "h": 680,
+                                                                                "w": 470,
+                                                                                "resize": "fit"
+                                                                            },
+                                                                            "thumb": {
+                                                                                "h": 150,
+                                                                                "w": 150,
+                                                                                "resize": "crop"
+                                                                            }
+                                                                        },
+                                                                        "original_info": {
+                                                                            "height": 1314,
+                                                                            "width": 908,
+                                                                            "focus_rects": [
+                                                                                {
+                                                                                    "x": 0,
+                                                                                    "y": 0,
+                                                                                    "w": 908,
+                                                                                    "h": 508
+                                                                                },
+                                                                                {
+                                                                                    "x": 0,
+                                                                                    "y": 0,
+                                                                                    "w": 908,
+                                                                                    "h": 908
+                                                                                },
+                                                                                {
+                                                                                    "x": 0,
+                                                                                    "y": 0,
+                                                                                    "w": 908,
+                                                                                    "h": 1035
+                                                                                },
+                                                                                {
+                                                                                    "x": 251,
+                                                                                    "y": 0,
+                                                                                    "w": 657,
+                                                                                    "h": 1314
+                                                                                },
+                                                                                {
+                                                                                    "x": 0,
+                                                                                    "y": 0,
+                                                                                    "w": 908,
+                                                                                    "h": 1314
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "media_results": {
+                                                                            "result": {
+                                                                                "media_key": "3_1889722022625787904"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "favorite_count": 0,
+                                                            "favorited": false,
+                                                            "full_text": "RT @elonmusk: https://t.co/7NzFTkFjhk",
+                                                            "is_quote_status": false,
+                                                            "lang": "zxx",
+                                                            "possibly_sensitive": false,
+                                                            "possibly_sensitive_editable": true,
+                                                            "quote_count": 0,
+                                                            "reply_count": 0,
+                                                            "retweet_count": 41552,
+                                                            "retweeted": true,
+                                                            "user_id_str": "1769424777998180352",
+                                                            "id_str": "1889737037189611592",
+                                                            "retweeted_status_result": {
+                                                                "result": {
+                                                                    "__typename": "Tweet",
+                                                                    "rest_id": "1889722028120285217",
+                                                                    "core": {
+                                                                        "user_results": {
+                                                                            "result": {
+                                                                                "__typename": "User",
+                                                                                "id": "VXNlcjo0NDE5NjM5Nw==",
+                                                                                "rest_id": "44196397",
+                                                                                "affiliates_highlighted_label": {
+                                                                                    "label": {
+                                                                                        "url": {
+                                                                                            "url": "https://twitter.com/X",
+                                                                                            "urlType": "DeepLink"
+                                                                                        },
+                                                                                        "badge": {
+                                                                                            "url": "https://pbs.twimg.com/profile_images/1683899100922511378/5lY42eHs_bigger.jpg"
+                                                                                        },
+                                                                                        "description": "X",
+                                                                                        "userLabelType": "BusinessLabel",
+                                                                                        "userLabelDisplayType": "Badge"
+                                                                                    }
+                                                                                },
+                                                                                "has_graduated_access": true,
+                                                                                "parody_commentary_fan_label": "None",
+                                                                                "is_blue_verified": true,
+                                                                                "profile_image_shape": "Circle",
+                                                                                "legacy": {
+                                                                                    "following": false,
+                                                                                    "can_dm": false,
+                                                                                    "can_media_tag": false,
+                                                                                    "created_at": "Tue Jun 02 20:12:29 +0000 2009",
+                                                                                    "default_profile": false,
+                                                                                    "default_profile_image": false,
+                                                                                    "description": "",
+                                                                                    "entities": {
+                                                                                        "description": {
+                                                                                            "urls": []
+                                                                                        }
+                                                                                    },
+                                                                                    "fast_followers_count": 0,
+                                                                                    "favourites_count": 139624,
+                                                                                    "followers_count": 218701925,
+                                                                                    "friends_count": 1102,
+                                                                                    "has_custom_timelines": true,
+                                                                                    "is_translator": false,
+                                                                                    "listed_count": 161717,
+                                                                                    "location": "",
+                                                                                    "media_count": 3750,
+                                                                                    "name": "Elon Musk",
+                                                                                    "normal_followers_count": 218701925,
+                                                                                    "pinned_tweet_ids_str": [
+                                                                                        "1908025106795823436"
+                                                                                    ],
+                                                                                    "possibly_sensitive": false,
+                                                                                    "profile_banner_url": "https://pbs.twimg.com/profile_banners/44196397/1739948056",
+                                                                                    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1893803697185910784/Na5lOWi5_normal.jpg",
+                                                                                    "profile_interstitial_type": "",
+                                                                                    "screen_name": "elonmusk",
+                                                                                    "statuses_count": 76433,
+                                                                                    "translator_type": "none",
+                                                                                    "verified": false,
+                                                                                    "want_retweets": false,
+                                                                                    "withheld_in_countries": []
+                                                                                },
+                                                                                "professional": {
+                                                                                    "rest_id": "1679729435447275522",
+                                                                                    "professional_type": "Creator",
+                                                                                    "category": []
+                                                                                },
+                                                                                "tipjar_settings": {
+                                                                                    "is_enabled": false
+                                                                                },
+                                                                                "super_follow_eligible": true
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "unmention_data": {},
+                                                                    "edit_control": {
+                                                                        "edit_tweet_ids": [
+                                                                            "1889722028120285217"
+                                                                        ],
+                                                                        "editable_until_msecs": "1739383415000",
+                                                                        "is_edit_eligible": true,
+                                                                        "edits_remaining": "5"
+                                                                    },
+                                                                    "is_translatable": false,
+                                                                    "views": {
+                                                                        "count": "40517235",
+                                                                        "state": "EnabledWithCount"
+                                                                    },
+                                                                    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+                                                                    "grok_analysis_button": true,
+                                                                    "legacy": {
+                                                                        "bookmark_count": 16279,
+                                                                        "bookmarked": false,
+                                                                        "created_at": "Wed Feb 12 17:03:35 +0000 2025",
+                                                                        "conversation_id_str": "1889722028120285217",
+                                                                        "display_text_range": [
+                                                                            0,
+                                                                            0
+                                                                        ],
+                                                                        "entities": {
+                                                                            "hashtags": [],
+                                                                            "media": [
+                                                                                {
+                                                                                    "display_url": "pic.x.com/7NzFTkFjhk",
+                                                                                    "expanded_url": "https://x.com/elonmusk/status/1889722028120285217/photo/1",
+                                                                                    "id_str": "1889722022625787904",
+                                                                                    "indices": [
+                                                                                        0,
+                                                                                        23
+                                                                                    ],
+                                                                                    "media_key": "3_1889722022625787904",
+                                                                                    "media_url_https": "https://pbs.twimg.com/media/GjmkKtrXwAAS5Vq.jpg",
+                                                                                    "type": "photo",
+                                                                                    "url": "https://t.co/7NzFTkFjhk",
+                                                                                    "ext_media_availability": {
+                                                                                        "status": "Available"
+                                                                                    },
+                                                                                    "features": {
+                                                                                        "large": {
+                                                                                            "faces": []
+                                                                                        },
+                                                                                        "medium": {
+                                                                                            "faces": []
+                                                                                        },
+                                                                                        "small": {
+                                                                                            "faces": []
+                                                                                        },
+                                                                                        "orig": {
+                                                                                            "faces": []
+                                                                                        }
+                                                                                    },
+                                                                                    "sizes": {
+                                                                                        "large": {
+                                                                                            "h": 1314,
+                                                                                            "w": 908,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "medium": {
+                                                                                            "h": 1200,
+                                                                                            "w": 829,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "small": {
+                                                                                            "h": 680,
+                                                                                            "w": 470,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "thumb": {
+                                                                                            "h": 150,
+                                                                                            "w": 150,
+                                                                                            "resize": "crop"
+                                                                                        }
+                                                                                    },
+                                                                                    "original_info": {
+                                                                                        "height": 1314,
+                                                                                        "width": 908,
+                                                                                        "focus_rects": [
+                                                                                            {
+                                                                                                "x": 0,
+                                                                                                "y": 0,
+                                                                                                "w": 908,
+                                                                                                "h": 508
+                                                                                            },
+                                                                                            {
+                                                                                                "x": 0,
+                                                                                                "y": 0,
+                                                                                                "w": 908,
+                                                                                                "h": 908
+                                                                                            },
+                                                                                            {
+                                                                                                "x": 0,
+                                                                                                "y": 0,
+                                                                                                "w": 908,
+                                                                                                "h": 1035
+                                                                                            },
+                                                                                            {
+                                                                                                "x": 251,
+                                                                                                "y": 0,
+                                                                                                "w": 657,
+                                                                                                "h": 1314
+                                                                                            },
+                                                                                            {
+                                                                                                "x": 0,
+                                                                                                "y": 0,
+                                                                                                "w": 908,
+                                                                                                "h": 1314
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    "media_results": {
+                                                                                        "result": {
+                                                                                            "media_key": "3_1889722022625787904"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            ],
+                                                                            "symbols": [],
+                                                                            "timestamps": [],
+                                                                            "urls": [],
+                                                                            "user_mentions": []
+                                                                        },
+                                                                        "extended_entities": {
+                                                                            "media": [
+                                                                                {
+                                                                                    "display_url": "pic.x.com/7NzFTkFjhk",
+                                                                                    "expanded_url": "https://x.com/elonmusk/status/1889722028120285217/photo/1",
+                                                                                    "id_str": "1889722022625787904",
+                                                                                    "indices": [
+                                                                                        0,
+                                                                                        23
+                                                                                    ],
+                                                                                    "media_key": "3_1889722022625787904",
+                                                                                    "media_url_https": "https://pbs.twimg.com/media/GjmkKtrXwAAS5Vq.jpg",
+                                                                                    "type": "photo",
+                                                                                    "url": "https://t.co/7NzFTkFjhk",
+                                                                                    "ext_media_availability": {
+                                                                                        "status": "Available"
+                                                                                    },
+                                                                                    "features": {
+                                                                                        "large": {
+                                                                                            "faces": []
+                                                                                        },
+                                                                                        "medium": {
+                                                                                            "faces": []
+                                                                                        },
+                                                                                        "small": {
+                                                                                            "faces": []
+                                                                                        },
+                                                                                        "orig": {
+                                                                                            "faces": []
+                                                                                        }
+                                                                                    },
+                                                                                    "sizes": {
+                                                                                        "large": {
+                                                                                            "h": 1314,
+                                                                                            "w": 908,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "medium": {
+                                                                                            "h": 1200,
+                                                                                            "w": 829,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "small": {
+                                                                                            "h": 680,
+                                                                                            "w": 470,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "thumb": {
+                                                                                            "h": 150,
+                                                                                            "w": 150,
+                                                                                            "resize": "crop"
+                                                                                        }
+                                                                                    },
+                                                                                    "original_info": {
+                                                                                        "height": 1314,
+                                                                                        "width": 908,
+                                                                                        "focus_rects": [
+                                                                                            {
+                                                                                                "x": 0,
+                                                                                                "y": 0,
+                                                                                                "w": 908,
+                                                                                                "h": 508
+                                                                                            },
+                                                                                            {
+                                                                                                "x": 0,
+                                                                                                "y": 0,
+                                                                                                "w": 908,
+                                                                                                "h": 908
+                                                                                            },
+                                                                                            {
+                                                                                                "x": 0,
+                                                                                                "y": 0,
+                                                                                                "w": 908,
+                                                                                                "h": 1035
+                                                                                            },
+                                                                                            {
+                                                                                                "x": 251,
+                                                                                                "y": 0,
+                                                                                                "w": 657,
+                                                                                                "h": 1314
+                                                                                            },
+                                                                                            {
+                                                                                                "x": 0,
+                                                                                                "y": 0,
+                                                                                                "w": 908,
+                                                                                                "h": 1314
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    "media_results": {
+                                                                                        "result": {
+                                                                                            "media_key": "3_1889722022625787904"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "favorite_count": 336673,
+                                                                        "favorited": false,
+                                                                        "full_text": "https://t.co/7NzFTkFjhk",
+                                                                        "is_quote_status": false,
+                                                                        "lang": "zxx",
+                                                                        "possibly_sensitive": false,
+                                                                        "possibly_sensitive_editable": true,
+                                                                        "quote_count": 4613,
+                                                                        "reply_count": 16211,
+                                                                        "retweet_count": 41552,
+                                                                        "retweeted": true,
+                                                                        "user_id_str": "44196397",
+                                                                        "id_str": "1889722028120285217"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "tweetDisplayType": "Tweet"
+                                            },
+                                            "clientEventInfo": {
+                                                "component": "tweet",
+                                                "element": "tweet",
+                                                "details": {
+                                                    "timelinesDetails": {
+                                                        "injectionType": "RankedOrganicTweet",
+                                                        "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "entryId": "profile-conversation-1908263658341793805",
+                                        "sortIndex": "1908263658341793779",
+                                        "content": {
+                                            "entryType": "TimelineTimelineModule",
+                                            "__typename": "TimelineTimelineModule",
+                                            "items": [
+                                                {
+                                                    "entryId": "profile-conversation-1908263658341793805-tweet-1889721288207519894",
+                                                    "dispensable": true,
+                                                    "item": {
+                                                        "itemContent": {
+                                                            "itemType": "TimelineTweet",
+                                                            "__typename": "TimelineTweet",
+                                                            "tweet_results": {
+                                                                "result": {
+                                                                    "__typename": "Tweet",
+                                                                    "rest_id": "1889721288207519894",
+                                                                    "core": {
+                                                                        "user_results": {
+                                                                            "result": {
+                                                                                "__typename": "User",
+                                                                                "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                                "rest_id": "1769424777998180352",
+                                                                                "affiliates_highlighted_label": {},
+                                                                                "has_graduated_access": false,
+                                                                                "parody_commentary_fan_label": "None",
+                                                                                "is_blue_verified": false,
+                                                                                "profile_image_shape": "Circle",
+                                                                                "legacy": {
+                                                                                    "following": false,
+                                                                                    "can_dm": true,
+                                                                                    "can_media_tag": true,
+                                                                                    "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                                    "default_profile": true,
+                                                                                    "default_profile_image": false,
+                                                                                    "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                                    "entities": {
+                                                                                        "description": {
+                                                                                            "urls": []
+                                                                                        }
+                                                                                    },
+                                                                                    "fast_followers_count": 0,
+                                                                                    "favourites_count": 124,
+                                                                                    "followers_count": 0,
+                                                                                    "friends_count": 0,
+                                                                                    "has_custom_timelines": false,
+                                                                                    "is_translator": false,
+                                                                                    "listed_count": 0,
+                                                                                    "location": "",
+                                                                                    "media_count": 0,
+                                                                                    "name": "aurorabyte",
+                                                                                    "needs_phone_verification": false,
+                                                                                    "normal_followers_count": 0,
+                                                                                    "pinned_tweet_ids_str": [],
+                                                                                    "possibly_sensitive": false,
+                                                                                    "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                                    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                                    "profile_interstitial_type": "",
+                                                                                    "screen_name": "aurorabyte79324",
+                                                                                    "statuses_count": 355,
+                                                                                    "translator_type": "none",
+                                                                                    "verified": false,
+                                                                                    "want_retweets": false,
+                                                                                    "withheld_in_countries": []
+                                                                                },
+                                                                                "tipjar_settings": {}
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "unmention_data": {},
+                                                                    "edit_control": {
+                                                                        "edit_tweet_ids": [
+                                                                            "1889721288207519894"
+                                                                        ],
+                                                                        "editable_until_msecs": "1739383239000",
+                                                                        "is_edit_eligible": false,
+                                                                        "edits_remaining": "5"
+                                                                    },
+                                                                    "is_translatable": false,
+                                                                    "views": {
+                                                                        "count": "6",
+                                                                        "state": "EnabledWithCount"
+                                                                    },
+                                                                    "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                                    "grok_analysis_button": true,
+                                                                    "legacy": {
+                                                                        "bookmark_count": 0,
+                                                                        "bookmarked": false,
+                                                                        "created_at": "Wed Feb 12 17:00:39 +0000 2025",
+                                                                        "conversation_id_str": "1889721288207519894",
+                                                                        "display_text_range": [
+                                                                            0,
+                                                                            42
+                                                                        ],
+                                                                        "entities": {
+                                                                            "hashtags": [],
+                                                                            "symbols": [],
+                                                                            "timestamps": [],
+                                                                            "urls": [],
+                                                                            "user_mentions": []
+                                                                        },
+                                                                        "favorite_count": 0,
+                                                                        "favorited": false,
+                                                                        "full_text": "Where code meets canvas and creates beauty",
+                                                                        "is_quote_status": false,
+                                                                        "lang": "en",
+                                                                        "quote_count": 0,
+                                                                        "reply_count": 2,
+                                                                        "retweet_count": 0,
+                                                                        "retweeted": false,
+                                                                        "user_id_str": "1769424777998180352",
+                                                                        "id_str": "1889721288207519894"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "tweetDisplayType": "Tweet"
+                                                        },
+                                                        "clientEventInfo": {
+                                                            "component": "tweet",
+                                                            "element": "tweet",
+                                                            "details": {
+                                                                "timelinesDetails": {
+                                                                    "injectionType": "RankedOrganicTweet",
+                                                                    "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "entryId": "profile-conversation-1908263658341793805-tweet-1889731804531130598",
+                                                    "dispensable": false,
+                                                    "item": {
+                                                        "itemContent": {
+                                                            "itemType": "TimelineTweet",
+                                                            "__typename": "TimelineTweet",
+                                                            "tweet_results": {
+                                                                "result": {
+                                                                    "__typename": "Tweet",
+                                                                    "rest_id": "1889731804531130598",
+                                                                    "core": {
+                                                                        "user_results": {
+                                                                            "result": {
+                                                                                "__typename": "User",
+                                                                                "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                                "rest_id": "1769424777998180352",
+                                                                                "affiliates_highlighted_label": {},
+                                                                                "has_graduated_access": false,
+                                                                                "parody_commentary_fan_label": "None",
+                                                                                "is_blue_verified": false,
+                                                                                "profile_image_shape": "Circle",
+                                                                                "legacy": {
+                                                                                    "following": false,
+                                                                                    "can_dm": true,
+                                                                                    "can_media_tag": true,
+                                                                                    "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                                    "default_profile": true,
+                                                                                    "default_profile_image": false,
+                                                                                    "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                                    "entities": {
+                                                                                        "description": {
+                                                                                            "urls": []
+                                                                                        }
+                                                                                    },
+                                                                                    "fast_followers_count": 0,
+                                                                                    "favourites_count": 124,
+                                                                                    "followers_count": 0,
+                                                                                    "friends_count": 0,
+                                                                                    "has_custom_timelines": false,
+                                                                                    "is_translator": false,
+                                                                                    "listed_count": 0,
+                                                                                    "location": "",
+                                                                                    "media_count": 0,
+                                                                                    "name": "aurorabyte",
+                                                                                    "needs_phone_verification": false,
+                                                                                    "normal_followers_count": 0,
+                                                                                    "pinned_tweet_ids_str": [],
+                                                                                    "possibly_sensitive": false,
+                                                                                    "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                                    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                                    "profile_interstitial_type": "",
+                                                                                    "screen_name": "aurorabyte79324",
+                                                                                    "statuses_count": 355,
+                                                                                    "translator_type": "none",
+                                                                                    "verified": false,
+                                                                                    "want_retweets": false,
+                                                                                    "withheld_in_countries": []
+                                                                                },
+                                                                                "tipjar_settings": {}
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "unmention_data": {},
+                                                                    "edit_control": {
+                                                                        "edit_tweet_ids": [
+                                                                            "1889731804531130598"
+                                                                        ],
+                                                                        "editable_until_msecs": "1739385746000",
+                                                                        "is_edit_eligible": false,
+                                                                        "edits_remaining": "5"
+                                                                    },
+                                                                    "is_translatable": false,
+                                                                    "views": {
+                                                                        "state": "Enabled"
+                                                                    },
+                                                                    "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                                    "grok_analysis_button": true,
+                                                                    "legacy": {
+                                                                        "bookmark_count": 0,
+                                                                        "bookmarked": false,
+                                                                        "created_at": "Wed Feb 12 17:42:26 +0000 2025",
+                                                                        "conversation_id_str": "1889721288207519894",
+                                                                        "display_text_range": [
+                                                                            0,
+                                                                            48
+                                                                        ],
+                                                                        "entities": {
+                                                                            "hashtags": [],
+                                                                            "symbols": [],
+                                                                            "timestamps": [],
+                                                                            "urls": [],
+                                                                            "user_mentions": []
+                                                                        },
+                                                                        "favorite_count": 0,
+                                                                        "favorited": false,
+                                                                        "full_text": "Revolutionizing art with the power of technology",
+                                                                        "in_reply_to_screen_name": "aurorabyte79324",
+                                                                        "in_reply_to_status_id_str": "1889721288207519894",
+                                                                        "in_reply_to_user_id_str": "1769424777998180352",
+                                                                        "is_quote_status": false,
+                                                                        "lang": "en",
+                                                                        "quote_count": 0,
+                                                                        "reply_count": 0,
+                                                                        "retweet_count": 0,
+                                                                        "retweeted": false,
+                                                                        "user_id_str": "1769424777998180352",
+                                                                        "id_str": "1889731804531130598"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "tweetDisplayType": "Tweet"
+                                                        },
+                                                        "clientEventInfo": {
+                                                            "component": "tweet",
+                                                            "element": "tweet",
+                                                            "details": {
+                                                                "timelinesDetails": {
+                                                                    "injectionType": "RankedOrganicTweet",
+                                                                    "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "metadata": {
+                                                "conversationMetadata": {
+                                                    "allTweetIds": [
+                                                        "1889721288207519894",
+                                                        "1889731804531130598"
+                                                    ],
+                                                    "enableDeduplication": true
+                                                }
+                                            },
+                                            "displayType": "VerticalConversation",
+                                            "clientEventInfo": {
+                                                "component": "suggest_ranked_organic_tweet",
+                                                "details": {
+                                                    "timelinesDetails": {
+                                                        "injectionType": "RankedOrganicTweet",
+                                                        "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "entryId": "profile-conversation-1908263658341793806",
+                                        "sortIndex": "1908263658341793778",
+                                        "content": {
+                                            "entryType": "TimelineTimelineModule",
+                                            "__typename": "TimelineTimelineModule",
+                                            "items": [
+                                                {
+                                                    "entryId": "profile-conversation-1908263658341793806-tweet-1889731761887735900",
+                                                    "dispensable": false,
+                                                    "item": {
+                                                        "itemContent": {
+                                                            "itemType": "TimelineTweet",
+                                                            "__typename": "TimelineTweet",
+                                                            "tweet_results": {
+                                                                "result": {
+                                                                    "__typename": "Tweet",
+                                                                    "rest_id": "1889731761887735900",
+                                                                    "core": {
+                                                                        "user_results": {
+                                                                            "result": {
+                                                                                "__typename": "User",
+                                                                                "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                                "rest_id": "1769424777998180352",
+                                                                                "affiliates_highlighted_label": {},
+                                                                                "has_graduated_access": false,
+                                                                                "parody_commentary_fan_label": "None",
+                                                                                "is_blue_verified": false,
+                                                                                "profile_image_shape": "Circle",
+                                                                                "legacy": {
+                                                                                    "following": false,
+                                                                                    "can_dm": true,
+                                                                                    "can_media_tag": true,
+                                                                                    "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                                    "default_profile": true,
+                                                                                    "default_profile_image": false,
+                                                                                    "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                                    "entities": {
+                                                                                        "description": {
+                                                                                            "urls": []
+                                                                                        }
+                                                                                    },
+                                                                                    "fast_followers_count": 0,
+                                                                                    "favourites_count": 124,
+                                                                                    "followers_count": 0,
+                                                                                    "friends_count": 0,
+                                                                                    "has_custom_timelines": false,
+                                                                                    "is_translator": false,
+                                                                                    "listed_count": 0,
+                                                                                    "location": "",
+                                                                                    "media_count": 0,
+                                                                                    "name": "aurorabyte",
+                                                                                    "needs_phone_verification": false,
+                                                                                    "normal_followers_count": 0,
+                                                                                    "pinned_tweet_ids_str": [],
+                                                                                    "possibly_sensitive": false,
+                                                                                    "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                                    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                                    "profile_interstitial_type": "",
+                                                                                    "screen_name": "aurorabyte79324",
+                                                                                    "statuses_count": 355,
+                                                                                    "translator_type": "none",
+                                                                                    "verified": false,
+                                                                                    "want_retweets": false,
+                                                                                    "withheld_in_countries": []
+                                                                                },
+                                                                                "tipjar_settings": {}
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "unmention_data": {},
+                                                                    "edit_control": {
+                                                                        "edit_tweet_ids": [
+                                                                            "1889731761887735900"
+                                                                        ],
+                                                                        "editable_until_msecs": "1739385736000",
+                                                                        "is_edit_eligible": false,
+                                                                        "edits_remaining": "5"
+                                                                    },
+                                                                    "is_translatable": false,
+                                                                    "views": {
+                                                                        "state": "Enabled"
+                                                                    },
+                                                                    "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                                    "grok_analysis_button": true,
+                                                                    "legacy": {
+                                                                        "bookmark_count": 0,
+                                                                        "bookmarked": false,
+                                                                        "created_at": "Wed Feb 12 17:42:16 +0000 2025",
+                                                                        "conversation_id_str": "1889726300694163477",
+                                                                        "display_text_range": [
+                                                                            15,
+                                                                            51
+                                                                        ],
+                                                                        "entities": {
+                                                                            "hashtags": [],
+                                                                            "symbols": [],
+                                                                            "timestamps": [],
+                                                                            "urls": [],
+                                                                            "user_mentions": [
+                                                                                {
+                                                                                    "id_str": "1769426369526771712",
+                                                                                    "name": "nexamind",
+                                                                                    "screen_name": "nexamind91326",
+                                                                                    "indices": [
+                                                                                        0,
+                                                                                        14
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "favorite_count": 0,
+                                                                        "favorited": false,
+                                                                        "full_text": "@nexamind91326 Transformative art, powered by bytes",
+                                                                        "in_reply_to_screen_name": "nexamind91326",
+                                                                        "in_reply_to_status_id_str": "1889726300694163477",
+                                                                        "in_reply_to_user_id_str": "1769426369526771712",
+                                                                        "is_quote_status": false,
+                                                                        "lang": "en",
+                                                                        "quote_count": 0,
+                                                                        "reply_count": 0,
+                                                                        "retweet_count": 0,
+                                                                        "retweeted": false,
+                                                                        "user_id_str": "1769424777998180352",
+                                                                        "id_str": "1889731761887735900"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "tweetDisplayType": "Tweet"
+                                                        },
+                                                        "clientEventInfo": {
+                                                            "component": "tweet",
+                                                            "element": "tweet",
+                                                            "details": {
+                                                                "timelinesDetails": {
+                                                                    "injectionType": "RankedOrganicTweet",
+                                                                    "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "metadata": {
+                                                "conversationMetadata": {
+                                                    "allTweetIds": [
+                                                        "1889726300694163477",
+                                                        "1889731761887735900"
+                                                    ],
+                                                    "enableDeduplication": true
+                                                }
+                                            },
+                                            "displayType": "VerticalConversation",
+                                            "clientEventInfo": {
+                                                "component": "suggest_ranked_organic_tweet",
+                                                "details": {
+                                                    "timelinesDetails": {
+                                                        "injectionType": "RankedOrganicTweet",
+                                                        "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "entryId": "profile-conversation-1908263658341793807",
+                                        "sortIndex": "1908263658341793777",
+                                        "content": {
+                                            "entryType": "TimelineTimelineModule",
+                                            "__typename": "TimelineTimelineModule",
+                                            "items": [
+                                                {
+                                                    "entryId": "profile-conversation-1908263658341793807-tweet-1889729150572757238",
+                                                    "dispensable": false,
+                                                    "item": {
+                                                        "itemContent": {
+                                                            "itemType": "TimelineTweet",
+                                                            "__typename": "TimelineTweet",
+                                                            "tweet_results": {
+                                                                "result": {
+                                                                    "__typename": "Tweet",
+                                                                    "rest_id": "1889729150572757238",
+                                                                    "core": {
+                                                                        "user_results": {
+                                                                            "result": {
+                                                                                "__typename": "User",
+                                                                                "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                                "rest_id": "1769424777998180352",
+                                                                                "affiliates_highlighted_label": {},
+                                                                                "has_graduated_access": false,
+                                                                                "parody_commentary_fan_label": "None",
+                                                                                "is_blue_verified": false,
+                                                                                "profile_image_shape": "Circle",
+                                                                                "legacy": {
+                                                                                    "following": false,
+                                                                                    "can_dm": true,
+                                                                                    "can_media_tag": true,
+                                                                                    "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                                    "default_profile": true,
+                                                                                    "default_profile_image": false,
+                                                                                    "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                                    "entities": {
+                                                                                        "description": {
+                                                                                            "urls": []
+                                                                                        }
+                                                                                    },
+                                                                                    "fast_followers_count": 0,
+                                                                                    "favourites_count": 124,
+                                                                                    "followers_count": 0,
+                                                                                    "friends_count": 0,
+                                                                                    "has_custom_timelines": false,
+                                                                                    "is_translator": false,
+                                                                                    "listed_count": 0,
+                                                                                    "location": "",
+                                                                                    "media_count": 0,
+                                                                                    "name": "aurorabyte",
+                                                                                    "needs_phone_verification": false,
+                                                                                    "normal_followers_count": 0,
+                                                                                    "pinned_tweet_ids_str": [],
+                                                                                    "possibly_sensitive": false,
+                                                                                    "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                                    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                                    "profile_interstitial_type": "",
+                                                                                    "screen_name": "aurorabyte79324",
+                                                                                    "statuses_count": 355,
+                                                                                    "translator_type": "none",
+                                                                                    "verified": false,
+                                                                                    "want_retweets": false,
+                                                                                    "withheld_in_countries": []
+                                                                                },
+                                                                                "tipjar_settings": {}
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "unmention_data": {},
+                                                                    "edit_control": {
+                                                                        "edit_tweet_ids": [
+                                                                            "1889729150572757238"
+                                                                        ],
+                                                                        "editable_until_msecs": "1739385113000",
+                                                                        "is_edit_eligible": false,
+                                                                        "edits_remaining": "5"
+                                                                    },
+                                                                    "is_translatable": false,
+                                                                    "views": {
+                                                                        "count": "19",
+                                                                        "state": "EnabledWithCount"
+                                                                    },
+                                                                    "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                                    "grok_analysis_button": true,
+                                                                    "legacy": {
+                                                                        "bookmark_count": 0,
+                                                                        "bookmarked": false,
+                                                                        "created_at": "Wed Feb 12 17:31:53 +0000 2025",
+                                                                        "conversation_id_str": "1889721288207519894",
+                                                                        "display_text_range": [
+                                                                            0,
+                                                                            52
+                                                                        ],
+                                                                        "entities": {
+                                                                            "hashtags": [],
+                                                                            "symbols": [],
+                                                                            "timestamps": [],
+                                                                            "urls": [],
+                                                                            "user_mentions": []
+                                                                        },
+                                                                        "favorite_count": 0,
+                                                                        "favorited": false,
+                                                                        "full_text": "Designing the digital dreamscape, one byte at a time",
+                                                                        "in_reply_to_screen_name": "aurorabyte79324",
+                                                                        "in_reply_to_status_id_str": "1889721288207519894",
+                                                                        "in_reply_to_user_id_str": "1769424777998180352",
+                                                                        "is_quote_status": false,
+                                                                        "lang": "en",
+                                                                        "quote_count": 0,
+                                                                        "reply_count": 0,
+                                                                        "retweet_count": 0,
+                                                                        "retweeted": false,
+                                                                        "user_id_str": "1769424777998180352",
+                                                                        "id_str": "1889729150572757238"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "tweetDisplayType": "Tweet"
+                                                        },
+                                                        "clientEventInfo": {
+                                                            "component": "tweet",
+                                                            "element": "tweet",
+                                                            "details": {
+                                                                "timelinesDetails": {
+                                                                    "injectionType": "RankedOrganicTweet",
+                                                                    "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "metadata": {
+                                                "conversationMetadata": {
+                                                    "allTweetIds": [
+                                                        "1889721288207519894",
+                                                        "1889729150572757238"
+                                                    ],
+                                                    "enableDeduplication": true
+                                                }
+                                            },
+                                            "displayType": "VerticalConversation",
+                                            "clientEventInfo": {
+                                                "component": "suggest_ranked_organic_tweet",
+                                                "details": {
+                                                    "timelinesDetails": {
+                                                        "injectionType": "RankedOrganicTweet",
+                                                        "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "entryId": "profile-conversation-1908263658341793808",
+                                        "sortIndex": "1908263658341793776",
+                                        "content": {
+                                            "entryType": "TimelineTimelineModule",
+                                            "__typename": "TimelineTimelineModule",
+                                            "items": [
+                                                {
+                                                    "entryId": "profile-conversation-1908263658341793808-tweet-1889729113402794466",
+                                                    "dispensable": false,
+                                                    "item": {
+                                                        "itemContent": {
+                                                            "itemType": "TimelineTweet",
+                                                            "__typename": "TimelineTweet",
+                                                            "tweet_results": {
+                                                                "result": {
+                                                                    "__typename": "Tweet",
+                                                                    "rest_id": "1889729113402794466",
+                                                                    "core": {
+                                                                        "user_results": {
+                                                                            "result": {
+                                                                                "__typename": "User",
+                                                                                "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                                "rest_id": "1769424777998180352",
+                                                                                "affiliates_highlighted_label": {},
+                                                                                "has_graduated_access": false,
+                                                                                "parody_commentary_fan_label": "None",
+                                                                                "is_blue_verified": false,
+                                                                                "profile_image_shape": "Circle",
+                                                                                "legacy": {
+                                                                                    "following": false,
+                                                                                    "can_dm": true,
+                                                                                    "can_media_tag": true,
+                                                                                    "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                                    "default_profile": true,
+                                                                                    "default_profile_image": false,
+                                                                                    "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                                    "entities": {
+                                                                                        "description": {
+                                                                                            "urls": []
+                                                                                        }
+                                                                                    },
+                                                                                    "fast_followers_count": 0,
+                                                                                    "favourites_count": 124,
+                                                                                    "followers_count": 0,
+                                                                                    "friends_count": 0,
+                                                                                    "has_custom_timelines": false,
+                                                                                    "is_translator": false,
+                                                                                    "listed_count": 0,
+                                                                                    "location": "",
+                                                                                    "media_count": 0,
+                                                                                    "name": "aurorabyte",
+                                                                                    "needs_phone_verification": false,
+                                                                                    "normal_followers_count": 0,
+                                                                                    "pinned_tweet_ids_str": [],
+                                                                                    "possibly_sensitive": false,
+                                                                                    "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                                    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                                    "profile_interstitial_type": "",
+                                                                                    "screen_name": "aurorabyte79324",
+                                                                                    "statuses_count": 355,
+                                                                                    "translator_type": "none",
+                                                                                    "verified": false,
+                                                                                    "want_retweets": false,
+                                                                                    "withheld_in_countries": []
+                                                                                },
+                                                                                "tipjar_settings": {}
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "unmention_data": {},
+                                                                    "edit_control": {
+                                                                        "edit_tweet_ids": [
+                                                                            "1889729113402794466"
+                                                                        ],
+                                                                        "editable_until_msecs": "1739385104000",
+                                                                        "is_edit_eligible": false,
+                                                                        "edits_remaining": "5"
+                                                                    },
+                                                                    "is_translatable": false,
+                                                                    "views": {
+                                                                        "state": "Enabled"
+                                                                    },
+                                                                    "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                                    "grok_analysis_button": true,
+                                                                    "legacy": {
+                                                                        "bookmark_count": 0,
+                                                                        "bookmarked": false,
+                                                                        "created_at": "Wed Feb 12 17:31:44 +0000 2025",
+                                                                        "conversation_id_str": "1889726300694163477",
+                                                                        "display_text_range": [
+                                                                            15,
+                                                                            48
+                                                                        ],
+                                                                        "entities": {
+                                                                            "hashtags": [],
+                                                                            "symbols": [],
+                                                                            "timestamps": [],
+                                                                            "urls": [],
+                                                                            "user_mentions": [
+                                                                                {
+                                                                                    "id_str": "1769426369526771712",
+                                                                                    "name": "nexamind",
+                                                                                    "screen_name": "nexamind91326",
+                                                                                    "indices": [
+                                                                                        0,
+                                                                                        14
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "favorite_count": 0,
+                                                                        "favorited": false,
+                                                                        "full_text": "@nexamind91326 The alchemy of art and technology",
+                                                                        "in_reply_to_screen_name": "nexamind91326",
+                                                                        "in_reply_to_status_id_str": "1889726300694163477",
+                                                                        "in_reply_to_user_id_str": "1769426369526771712",
+                                                                        "is_quote_status": false,
+                                                                        "lang": "en",
+                                                                        "quote_count": 0,
+                                                                        "reply_count": 0,
+                                                                        "retweet_count": 0,
+                                                                        "retweeted": false,
+                                                                        "user_id_str": "1769424777998180352",
+                                                                        "id_str": "1889729113402794466"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "tweetDisplayType": "Tweet"
+                                                        },
+                                                        "clientEventInfo": {
+                                                            "component": "tweet",
+                                                            "element": "tweet",
+                                                            "details": {
+                                                                "timelinesDetails": {
+                                                                    "injectionType": "RankedOrganicTweet",
+                                                                    "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "metadata": {
+                                                "conversationMetadata": {
+                                                    "allTweetIds": [
+                                                        "1889726300694163477",
+                                                        "1889729113402794466"
+                                                    ],
+                                                    "enableDeduplication": true
+                                                }
+                                            },
+                                            "displayType": "VerticalConversation",
+                                            "clientEventInfo": {
+                                                "component": "suggest_ranked_organic_tweet",
+                                                "details": {
+                                                    "timelinesDetails": {
+                                                        "injectionType": "RankedOrganicTweet",
+                                                        "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "entryId": "tweet-1889723877799907788",
+                                        "sortIndex": "1908263658341793775",
+                                        "content": {
+                                            "entryType": "TimelineTimelineItem",
+                                            "__typename": "TimelineTimelineItem",
+                                            "itemContent": {
+                                                "itemType": "TimelineTweet",
+                                                "__typename": "TimelineTweet",
+                                                "tweet_results": {
+                                                    "result": {
+                                                        "__typename": "Tweet",
+                                                        "rest_id": "1889723877799907788",
+                                                        "core": {
+                                                            "user_results": {
+                                                                "result": {
+                                                                    "__typename": "User",
+                                                                    "id": "VXNlcjoxNzY5NDI0Nzc3OTk4MTgwMzUy",
+                                                                    "rest_id": "1769424777998180352",
+                                                                    "affiliates_highlighted_label": {},
+                                                                    "has_graduated_access": false,
+                                                                    "parody_commentary_fan_label": "None",
+                                                                    "is_blue_verified": false,
+                                                                    "profile_image_shape": "Circle",
+                                                                    "legacy": {
+                                                                        "following": false,
+                                                                        "can_dm": true,
+                                                                        "can_media_tag": true,
+                                                                        "created_at": "Sun Mar 17 18:07:40 +0000 2024",
+                                                                        "default_profile": true,
+                                                                        "default_profile_image": false,
+                                                                        "description": "weaving digital auroras and vibrant bytes, illuminating the canvas of creativity with the colors of innovation",
+                                                                        "entities": {
+                                                                            "description": {
+                                                                                "urls": []
+                                                                            }
+                                                                        },
+                                                                        "fast_followers_count": 0,
+                                                                        "favourites_count": 124,
+                                                                        "followers_count": 0,
+                                                                        "friends_count": 0,
+                                                                        "has_custom_timelines": false,
+                                                                        "is_translator": false,
+                                                                        "listed_count": 0,
+                                                                        "location": "",
+                                                                        "media_count": 0,
+                                                                        "name": "aurorabyte",
+                                                                        "needs_phone_verification": false,
+                                                                        "normal_followers_count": 0,
+                                                                        "pinned_tweet_ids_str": [],
+                                                                        "possibly_sensitive": false,
+                                                                        "profile_banner_url": "https://pbs.twimg.com/profile_banners/1769424777998180352/1710698956",
+                                                                        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1769425447799209984/gN-FV0ph_normal.jpg",
+                                                                        "profile_interstitial_type": "",
+                                                                        "screen_name": "aurorabyte79324",
+                                                                        "statuses_count": 355,
+                                                                        "translator_type": "none",
+                                                                        "verified": false,
+                                                                        "want_retweets": false,
+                                                                        "withheld_in_countries": []
+                                                                    },
+                                                                    "tipjar_settings": {}
+                                                                }
+                                                            }
+                                                        },
+                                                        "unmention_data": {},
+                                                        "edit_control": {
+                                                            "edit_tweet_ids": [
+                                                                "1889723877799907788"
+                                                            ],
+                                                            "editable_until_msecs": "1739383856496",
+                                                            "is_edit_eligible": false,
+                                                            "edits_remaining": "5"
+                                                        },
+                                                        "is_translatable": false,
+                                                        "views": {
+                                                            "state": "Enabled"
+                                                        },
+                                                        "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                        "grok_analysis_button": true,
+                                                        "legacy": {
+                                                            "bookmark_count": 0,
+                                                            "bookmarked": false,
+                                                            "created_at": "Wed Feb 12 17:10:56 +0000 2025",
+                                                            "conversation_id_str": "1889723877799907788",
+                                                            "display_text_range": [
+                                                                0,
+                                                                140
+                                                            ],
+                                                            "entities": {
+                                                                "hashtags": [],
+                                                                "symbols": [],
+                                                                "timestamps": [],
+                                                                "urls": [],
+                                                                "user_mentions": [
+                                                                    {
+                                                                        "id_str": "1319287761048723458",
+                                                                        "name": "Mario Nawfal",
+                                                                        "screen_name": "MarioNawfal",
+                                                                        "indices": [
+                                                                            3,
+                                                                            15
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "favorite_count": 0,
+                                                            "favorited": false,
+                                                            "full_text": "RT @MarioNawfal: \uD83D\uDEA8\uD83C\uDDFA\uD83C\uDDF8DOGE SLASHES $982M IN WASTE—EDUCATION BUREAUCRATS PANIC\n\nElon’s DOGE just saved taxpayers $982 million by cutting waste…",
+                                                            "is_quote_status": false,
+                                                            "lang": "en",
+                                                            "quote_count": 0,
+                                                            "reply_count": 0,
+                                                            "retweet_count": 4088,
+                                                            "retweeted": true,
+                                                            "user_id_str": "1769424777998180352",
+                                                            "id_str": "1889723877799907788",
+                                                            "retweeted_status_result": {
+                                                                "result": {
+                                                                    "__typename": "Tweet",
+                                                                    "rest_id": "1889699801479983383",
+                                                                    "core": {
+                                                                        "user_results": {
+                                                                            "result": {
+                                                                                "__typename": "User",
+                                                                                "id": "VXNlcjoxMzE5Mjg3NzYxMDQ4NzIzNDU4",
+                                                                                "rest_id": "1319287761048723458",
+                                                                                "affiliates_highlighted_label": {
+                                                                                    "label": {
+                                                                                        "url": {
+                                                                                            "url": "https://twitter.com/RoundtableSpace",
+                                                                                            "urlType": "DeepLink"
+                                                                                        },
+                                                                                        "badge": {
+                                                                                            "url": "https://pbs.twimg.com/profile_images/1750481240983994368/ijRW1a6Y_bigger.jpg"
+                                                                                        },
+                                                                                        "description": "Mario Nawfal’s Roundtable",
+                                                                                        "userLabelType": "BusinessLabel",
+                                                                                        "userLabelDisplayType": "Badge"
+                                                                                    }
+                                                                                },
+                                                                                "has_graduated_access": true,
+                                                                                "parody_commentary_fan_label": "None",
+                                                                                "is_blue_verified": true,
+                                                                                "profile_image_shape": "Circle",
+                                                                                "legacy": {
+                                                                                    "following": false,
+                                                                                    "can_dm": true,
+                                                                                    "can_media_tag": true,
+                                                                                    "created_at": "Thu Oct 22 14:42:25 +0000 2020",
+                                                                                    "default_profile": true,
+                                                                                    "default_profile_image": false,
+                                                                                    "description": "Largest Show on X | Founder @ibcgroupio | Investor 600+ Startups",
+                                                                                    "entities": {
+                                                                                        "description": {
+                                                                                            "urls": []
+                                                                                        },
+                                                                                        "url": {
+                                                                                            "urls": [
+                                                                                                {
+                                                                                                    "display_url": "roundtable.live",
+                                                                                                    "expanded_url": "https://roundtable.live",
+                                                                                                    "url": "https://t.co/Lru9VAixI8",
+                                                                                                    "indices": [
+                                                                                                        0,
+                                                                                                        23
+                                                                                                    ]
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "fast_followers_count": 0,
+                                                                                    "favourites_count": 150320,
+                                                                                    "followers_count": 2192268,
+                                                                                    "friends_count": 46241,
+                                                                                    "has_custom_timelines": true,
+                                                                                    "is_translator": false,
+                                                                                    "listed_count": 9336,
+                                                                                    "location": "",
+                                                                                    "media_count": 93570,
+                                                                                    "name": "Mario Nawfal",
+                                                                                    "normal_followers_count": 2192268,
+                                                                                    "pinned_tweet_ids_str": [
+                                                                                        "1908129339247370295"
+                                                                                    ],
+                                                                                    "possibly_sensitive": false,
+                                                                                    "profile_banner_url": "https://pbs.twimg.com/profile_banners/1319287761048723458/1743760560",
+                                                                                    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1670905743619268609/pYItlWat_normal.jpg",
+                                                                                    "profile_interstitial_type": "",
+                                                                                    "screen_name": "MarioNawfal",
+                                                                                    "statuses_count": 124533,
+                                                                                    "translator_type": "none",
+                                                                                    "url": "https://t.co/Lru9VAixI8",
+                                                                                    "verified": false,
+                                                                                    "want_retweets": false,
+                                                                                    "withheld_in_countries": []
+                                                                                },
+                                                                                "professional": {
+                                                                                    "rest_id": "1480816032101064705",
+                                                                                    "professional_type": "Business",
+                                                                                    "category": [
+                                                                                        {
+                                                                                            "id": 199,
+                                                                                            "name": "Investment Company",
+                                                                                            "icon_name": "IconBriefcaseStroke"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "tipjar_settings": {},
+                                                                                "super_follow_eligible": true
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "unmention_data": {},
+                                                                    "edit_control": {
+                                                                        "edit_tweet_ids": [
+                                                                            "1889699801479983383"
+                                                                        ],
+                                                                        "editable_until_msecs": "1739378116000",
+                                                                        "is_edit_eligible": true,
+                                                                        "edits_remaining": "5"
+                                                                    },
+                                                                    "is_translatable": false,
+                                                                    "views": {
+                                                                        "count": "1414694",
+                                                                        "state": "EnabledWithCount"
+                                                                    },
+                                                                    "source": "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+                                                                    "note_tweet": {
+                                                                        "is_expandable": true,
+                                                                        "note_tweet_results": {
+                                                                            "result": {
+                                                                                "id": "Tm90ZVR3ZWV0OjE4ODk2OTk4MDEyODcwMzI4MzI=",
+                                                                                "text": "\uD83D\uDEA8\uD83C\uDDFA\uD83C\uDDF8DOGE SLASHES $982M IN WASTE—EDUCATION BUREAUCRATS PANIC\n\nElon’s DOGE just saved taxpayers $982 million by cutting wasteful spending in the Department of Education. \n\nA staggering $881 million was axed from 89 bloated contracts, including unnecessary studies on “teaching strategies” and “educational trends.” \n\nAnother $101 million was saved by eliminating DEI training grants.\n\nTrump:\n\n“Nobody had any idea it was that bad, that sick, and that corrupt.” \n\nTrump signed an executive order directing all federal agencies to work with Elon’s team to root out waste, fraud, and abuse.\n\nMeanwhile, D.C. bureaucrats are in full meltdown mode, staging protests to “Save the Civil Service.” \n\nBut the truth is clear—Trump and Elon are delivering real results, cutting waste, and putting money back where it belongs: with the American people. And this is just the beginning.\n\nSource: Daily Mail",
+                                                                                "entity_set": {
+                                                                                    "hashtags": [],
+                                                                                    "symbols": [],
+                                                                                    "urls": [],
+                                                                                    "user_mentions": []
+                                                                                },
+                                                                                "richtext": {
+                                                                                    "richtext_tags": [
+                                                                                        {
+                                                                                            "from_index": 2,
+                                                                                            "to_index": 61,
+                                                                                            "richtext_types": [
+                                                                                                "Bold"
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "from_index": 393,
+                                                                                            "to_index": 461,
+                                                                                            "richtext_types": [
+                                                                                                "Italic"
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "media": {
+                                                                                    "inline_media": []
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "grok_analysis_button": true,
+                                                                    "legacy": {
+                                                                        "bookmark_count": 570,
+                                                                        "bookmarked": false,
+                                                                        "created_at": "Wed Feb 12 15:35:16 +0000 2025",
+                                                                        "conversation_id_str": "1889699801479983383",
+                                                                        "display_text_range": [
+                                                                            0,
+                                                                            273
+                                                                        ],
+                                                                        "entities": {
+                                                                            "hashtags": [],
+                                                                            "media": [
+                                                                                {
+                                                                                    "display_url": "pic.x.com/oqd5E7ZRNn",
+                                                                                    "expanded_url": "https://x.com/MarioNawfal/status/1889699801479983383/photo/1",
+                                                                                    "id_str": "1889699761202053121",
+                                                                                    "indices": [
+                                                                                        274,
+                                                                                        297
+                                                                                    ],
+                                                                                    "media_key": "3_1889699761202053121",
+                                                                                    "media_url_https": "https://pbs.twimg.com/media/GjmP67aWwAEgZpV.jpg",
+                                                                                    "type": "photo",
+                                                                                    "url": "https://t.co/oqd5E7ZRNn",
+                                                                                    "ext_media_availability": {
+                                                                                        "status": "Available"
+                                                                                    },
+                                                                                    "features": {
+                                                                                        "large": {
+                                                                                            "faces": [
+                                                                                                {
+                                                                                                    "x": 531,
+                                                                                                    "y": 71,
+                                                                                                    "h": 80,
+                                                                                                    "w": 80
+                                                                                                },
+                                                                                                {
+                                                                                                    "x": 315,
+                                                                                                    "y": 524,
+                                                                                                    "h": 75,
+                                                                                                    "w": 75
+                                                                                                },
+                                                                                                {
+                                                                                                    "x": 1096,
+                                                                                                    "y": 312,
+                                                                                                    "h": 105,
+                                                                                                    "w": 105
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "medium": {
+                                                                                            "faces": [
+                                                                                                {
+                                                                                                    "x": 442,
+                                                                                                    "y": 59,
+                                                                                                    "h": 66,
+                                                                                                    "w": 66
+                                                                                                },
+                                                                                                {
+                                                                                                    "x": 262,
+                                                                                                    "y": 436,
+                                                                                                    "h": 62,
+                                                                                                    "w": 62
+                                                                                                },
+                                                                                                {
+                                                                                                    "x": 913,
+                                                                                                    "y": 260,
+                                                                                                    "h": 87,
+                                                                                                    "w": 87
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "small": {
+                                                                                            "faces": [
+                                                                                                {
+                                                                                                    "x": 250,
+                                                                                                    "y": 33,
+                                                                                                    "h": 37,
+                                                                                                    "w": 37
+                                                                                                },
+                                                                                                {
+                                                                                                    "x": 148,
+                                                                                                    "y": 247,
+                                                                                                    "h": 35,
+                                                                                                    "w": 35
+                                                                                                },
+                                                                                                {
+                                                                                                    "x": 517,
+                                                                                                    "y": 147,
+                                                                                                    "h": 49,
+                                                                                                    "w": 49
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "orig": {
+                                                                                            "faces": [
+                                                                                                {
+                                                                                                    "x": 531,
+                                                                                                    "y": 71,
+                                                                                                    "h": 80,
+                                                                                                    "w": 80
+                                                                                                },
+                                                                                                {
+                                                                                                    "x": 315,
+                                                                                                    "y": 524,
+                                                                                                    "h": 75,
+                                                                                                    "w": 75
+                                                                                                },
+                                                                                                {
+                                                                                                    "x": 1096,
+                                                                                                    "y": 312,
+                                                                                                    "h": 105,
+                                                                                                    "w": 105
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "sizes": {
+                                                                                        "large": {
+                                                                                            "h": 1043,
+                                                                                            "w": 1440,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "medium": {
+                                                                                            "h": 869,
+                                                                                            "w": 1200,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "small": {
+                                                                                            "h": 493,
+                                                                                            "w": 680,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "thumb": {
+                                                                                            "h": 150,
+                                                                                            "w": 150,
+                                                                                            "resize": "crop"
+                                                                                        }
+                                                                                    },
+                                                                                    "original_info": {
+                                                                                        "height": 1043,
+                                                                                        "width": 1440,
+                                                                                        "focus_rects": [
+                                                                                            {
+                                                                                                "x": 0,
+                                                                                                "y": 0,
+                                                                                                "w": 1440,
+                                                                                                "h": 806
+                                                                                            },
+                                                                                            {
+                                                                                                "x": 18,
+                                                                                                "y": 0,
+                                                                                                "w": 1043,
+                                                                                                "h": 1043
+                                                                                            },
+                                                                                            {
+                                                                                                "x": 82,
+                                                                                                "y": 0,
+                                                                                                "w": 915,
+                                                                                                "h": 1043
+                                                                                            },
+                                                                                            {
+                                                                                                "x": 278,
+                                                                                                "y": 0,
+                                                                                                "w": 522,
+                                                                                                "h": 1043
+                                                                                            },
+                                                                                            {
+                                                                                                "x": 0,
+                                                                                                "y": 0,
+                                                                                                "w": 1440,
+                                                                                                "h": 1043
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    "media_results": {
+                                                                                        "result": {
+                                                                                            "media_key": "3_1889699761202053121"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            ],
+                                                                            "symbols": [],
+                                                                            "timestamps": [],
+                                                                            "urls": [],
+                                                                            "user_mentions": []
+                                                                        },
+                                                                        "extended_entities": {
+                                                                            "media": [
+                                                                                {
+                                                                                    "display_url": "pic.x.com/oqd5E7ZRNn",
+                                                                                    "expanded_url": "https://x.com/MarioNawfal/status/1889699801479983383/photo/1",
+                                                                                    "id_str": "1889699761202053121",
+                                                                                    "indices": [
+                                                                                        274,
+                                                                                        297
+                                                                                    ],
+                                                                                    "media_key": "3_1889699761202053121",
+                                                                                    "media_url_https": "https://pbs.twimg.com/media/GjmP67aWwAEgZpV.jpg",
+                                                                                    "type": "photo",
+                                                                                    "url": "https://t.co/oqd5E7ZRNn",
+                                                                                    "ext_media_availability": {
+                                                                                        "status": "Available"
+                                                                                    },
+                                                                                    "features": {
+                                                                                        "large": {
+                                                                                            "faces": [
+                                                                                                {
+                                                                                                    "x": 531,
+                                                                                                    "y": 71,
+                                                                                                    "h": 80,
+                                                                                                    "w": 80
+                                                                                                },
+                                                                                                {
+                                                                                                    "x": 315,
+                                                                                                    "y": 524,
+                                                                                                    "h": 75,
+                                                                                                    "w": 75
+                                                                                                },
+                                                                                                {
+                                                                                                    "x": 1096,
+                                                                                                    "y": 312,
+                                                                                                    "h": 105,
+                                                                                                    "w": 105
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "medium": {
+                                                                                            "faces": [
+                                                                                                {
+                                                                                                    "x": 442,
+                                                                                                    "y": 59,
+                                                                                                    "h": 66,
+                                                                                                    "w": 66
+                                                                                                },
+                                                                                                {
+                                                                                                    "x": 262,
+                                                                                                    "y": 436,
+                                                                                                    "h": 62,
+                                                                                                    "w": 62
+                                                                                                },
+                                                                                                {
+                                                                                                    "x": 913,
+                                                                                                    "y": 260,
+                                                                                                    "h": 87,
+                                                                                                    "w": 87
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "small": {
+                                                                                            "faces": [
+                                                                                                {
+                                                                                                    "x": 250,
+                                                                                                    "y": 33,
+                                                                                                    "h": 37,
+                                                                                                    "w": 37
+                                                                                                },
+                                                                                                {
+                                                                                                    "x": 148,
+                                                                                                    "y": 247,
+                                                                                                    "h": 35,
+                                                                                                    "w": 35
+                                                                                                },
+                                                                                                {
+                                                                                                    "x": 517,
+                                                                                                    "y": 147,
+                                                                                                    "h": 49,
+                                                                                                    "w": 49
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        "orig": {
+                                                                                            "faces": [
+                                                                                                {
+                                                                                                    "x": 531,
+                                                                                                    "y": 71,
+                                                                                                    "h": 80,
+                                                                                                    "w": 80
+                                                                                                },
+                                                                                                {
+                                                                                                    "x": 315,
+                                                                                                    "y": 524,
+                                                                                                    "h": 75,
+                                                                                                    "w": 75
+                                                                                                },
+                                                                                                {
+                                                                                                    "x": 1096,
+                                                                                                    "y": 312,
+                                                                                                    "h": 105,
+                                                                                                    "w": 105
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "sizes": {
+                                                                                        "large": {
+                                                                                            "h": 1043,
+                                                                                            "w": 1440,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "medium": {
+                                                                                            "h": 869,
+                                                                                            "w": 1200,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "small": {
+                                                                                            "h": 493,
+                                                                                            "w": 680,
+                                                                                            "resize": "fit"
+                                                                                        },
+                                                                                        "thumb": {
+                                                                                            "h": 150,
+                                                                                            "w": 150,
+                                                                                            "resize": "crop"
+                                                                                        }
+                                                                                    },
+                                                                                    "original_info": {
+                                                                                        "height": 1043,
+                                                                                        "width": 1440,
+                                                                                        "focus_rects": [
+                                                                                            {
+                                                                                                "x": 0,
+                                                                                                "y": 0,
+                                                                                                "w": 1440,
+                                                                                                "h": 806
+                                                                                            },
+                                                                                            {
+                                                                                                "x": 18,
+                                                                                                "y": 0,
+                                                                                                "w": 1043,
+                                                                                                "h": 1043
+                                                                                            },
+                                                                                            {
+                                                                                                "x": 82,
+                                                                                                "y": 0,
+                                                                                                "w": 915,
+                                                                                                "h": 1043
+                                                                                            },
+                                                                                            {
+                                                                                                "x": 278,
+                                                                                                "y": 0,
+                                                                                                "w": 522,
+                                                                                                "h": 1043
+                                                                                            },
+                                                                                            {
+                                                                                                "x": 0,
+                                                                                                "y": 0,
+                                                                                                "w": 1440,
+                                                                                                "h": 1043
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    "media_results": {
+                                                                                        "result": {
+                                                                                            "media_key": "3_1889699761202053121"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "favorite_count": 25332,
+                                                                        "favorited": false,
+                                                                        "full_text": "\uD83D\uDEA8\uD83C\uDDFA\uD83C\uDDF8DOGE SLASHES $982M IN WASTE—EDUCATION BUREAUCRATS PANIC\n\nElon’s DOGE just saved taxpayers $982 million by cutting wasteful spending in the Department of Education. \n\nA staggering $881 million was axed from 89 bloated contracts, including unnecessary studies on “teaching https://t.co/oqd5E7ZRNn",
+                                                                        "is_quote_status": false,
+                                                                        "lang": "en",
+                                                                        "possibly_sensitive": false,
+                                                                        "possibly_sensitive_editable": true,
+                                                                        "quote_count": 196,
+                                                                        "reply_count": 1151,
+                                                                        "retweet_count": 4088,
+                                                                        "retweeted": true,
+                                                                        "user_id_str": "1319287761048723458",
+                                                                        "id_str": "1889699801479983383"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "tweetDisplayType": "Tweet"
+                                            },
+                                            "clientEventInfo": {
+                                                "component": "tweet",
+                                                "element": "tweet",
+                                                "details": {
+                                                    "timelinesDetails": {
+                                                        "injectionType": "RankedOrganicTweet",
+                                                        "controllerData": "DAACDAABDAABCgABAAAAAAAAAAAKAAkYjkJ19VsgAAAAAAA="
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "entryId": "cursor-top-1908263658341793793",
+                                        "sortIndex": "1908263658341793793",
+                                        "content": {
+                                            "entryType": "TimelineTimelineCursor",
+                                            "__typename": "TimelineTimelineCursor",
+                                            "value": "DAABCgABGnuDr9VAJxEKAAIaOeEzEpdgGAgAAwAAAAEAAA",
+                                            "cursorType": "Top"
+                                        }
+                                    },
+                                    {
+                                        "entryId": "cursor-bottom-1908263658341793774",
+                                        "sortIndex": "1908263658341793774",
+                                        "content": {
+                                            "entryType": "TimelineTimelineCursor",
+                                            "__typename": "TimelineTimelineCursor",
+                                            "value": "DAABCgABGnuDr9U__-wKAAIaOaXay9ZRzAgAAwAAAAIAAA",
+                                            "cursorType": "Bottom"
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                        "metadata": {
+                            "scribeConfig": {
+                                "page": "profileAll"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #487 

We've received like 20 or so error reports in the last few days that are all extremely similar. After investigating, I've reproduced the problem and confirmed that we were expecting API responses to look like this:

```ts
{
    data: {
        user: {
            result: {
                __typename: string; // "User"
                timeline_v2: XAPITimeline;
            }
        }
    }
}
```

But the XAPITimeline object was getting set in `timeline`, not `timeline_v2`.

This PR fixes it, and adds a test that includes a real API response in the new format.