### PR TITLE
Make X SQL queries considerably more efficient

### DIFF
--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -3,15 +3,28 @@ import path from 'path';
 import os from 'os';
 import { execSync } from 'child_process';
 
-const directoriesToRemove = ['./out', './build', './node_modules'];
+const directoriesToRemove = ['./out', './node_modules'];
 
 directoriesToRemove.forEach((dir) => {
     const fullPath = path.resolve(dir);
     if (fs.existsSync(fullPath)) {
-        console.log(`Removing: ${fullPath}`);
+        console.log(`Deleting: ${fullPath}`);
         fs.rmSync(fullPath, { recursive: true, force: true });
     }
 });
+
+// Delete all files in the build directory except config.json
+const buildDir = path.resolve('./build');
+if (fs.existsSync(buildDir)) {
+    console.log(`Cleaning: ${buildDir}`);
+    fs.readdirSync(buildDir).forEach((file) => {
+        const filePath = path.join(buildDir, file);
+        if (file !== 'config.json') {
+            console.log(`Deleting: ${filePath}`);
+            fs.rmSync(filePath, { recursive: true, force: true });
+        }
+    });
+}
 
 console.log('Running npm install...');
 execSync('npm install', { stdio: 'inherit' });

--- a/src/account_x/x_account_controller.ts
+++ b/src/account_x/x_account_controller.ts
@@ -478,7 +478,7 @@ export class XAccountController {
             if (!tweetMap[row.tweetID]) {
                 tweetMap[row.tweetID] = {
                     id: row.tweetID,
-                    t: row.text.replace(/(?:\r\n|\r|\n)/g, '<br>').trim(),
+                    t: (row.text ? row.text.replace(/(?:\r\n|\r|\n)/g, '<br>').trim() : ""),
                     l: row.likeCount,
                     r: row.retweetCount,
                     d: row.createdAt,

--- a/src/renderer/src/view_models/XViewModel.ts
+++ b/src/renderer/src/view_models/XViewModel.ts
@@ -12,7 +12,6 @@ import {
     XProgressInfo, emptyXProgressInfo,
     XDeleteTweetsStartResponse,
     XDatabaseStats, emptyXDatabaseStats,
-    XDeleteReviewStats, emptyXDeleteReviewStats,
     XMigrateTweetCounts
 } from '../../../shared_types';
 import { XViewerResults, XUserInfo } from "../types_x"
@@ -104,7 +103,6 @@ export class XViewModel extends BaseViewModel {
     public rateLimitInfo: XRateLimitInfo = emptyXRateLimitInfo();
     public progressInfo: XProgressInfo = emptyXProgressInfo();
     public databaseStats: XDatabaseStats = emptyXDatabaseStats();
-    public deleteReviewStats: XDeleteReviewStats = emptyXDeleteReviewStats();
     public archiveInfo: ArchiveInfo = emptyArchiveInfo();
     public jobs: XJob[] = [];
     public currentJobIndex: number = 0;
@@ -133,7 +131,6 @@ export class XViewModel extends BaseViewModel {
 
     async refreshDatabaseStats() {
         this.databaseStats = await window.electron.X.getDatabaseStats(this.account.id);
-        this.deleteReviewStats = await window.electron.X.getDeleteReviewStats(this.account.id);
         this.archiveInfo = await window.electron.archive.getInfo(this.account.id);
         this.emitter?.emit(`x-update-database-stats-${this.account.id}`);
         this.emitter?.emit(`x-update-archive-info-${this.account.id}`);

--- a/src/renderer/src/views/x/XWizardReviewPage.vue
+++ b/src/renderer/src/views/x/XWizardReviewPage.vue
@@ -62,8 +62,7 @@ onMounted(async () => {
 
     jobsType.value = getJobsType(props.model.account.id) || '';
 
-    await props.model.refreshDatabaseStats();
-    deleteReviewStats.value = props.model.deleteReviewStats;
+    deleteReviewStats.value = await window.electron.X.getDeleteReviewStats(props.model.account.id);
     hasSomeData.value = await xHasSomeData(props.model.account.id);
     tweetCounts.value = await window.electron.X.blueskyGetTweetCounts(props.model.account.id) || emptyXMigrateTweetCounts();
 


### PR DESCRIPTION
Hopefully this will fix #428 and #492.

This PR should make the performance of using the X platform waaaaaay better.

## Only run `getDeleteReviewStats` IPC function when it needs to

Before, when an X account tab was loaded, it created an `XViewModel` object, which runs `refreshDatabaseStats` to update its internal state of the database stats. This included a call to the `getDeleteReviewStats` IPC function, which is used for the review page when you're getting ready to delete. It basically does some heavy database queries to learn the number of tweets, retweets, likes, etc. it's going to delete, based on your settings.

But `getDeleteReviewStats` only needs to get run when you get to the review page, not when a `XViewModel` is initialized, and not every time `refreshDatabaseStats` is called either.

This PR removes `getDeleteReviewStats` from `refreshDatabaseStats`, and instead manually calls it in the `onMounted` function of `XWizardReviewPage.vue`. So basically, the very resource-intensive IPC function is only called right when you're getting ready to review your changes, and not when you first open the app.

## Use 1 query instead of 1+2N queries, so it's a bazillion times faster if you have lots of data

The `getDeleteReviewStats` IPC function learns how many tweets, retweets, likes, etc. it's going to delete by calling the following functions in `XAccountController`:

- `deleteTweetsStart`
- `deleteRetweetsStart`
- `deleteLikesStart`
- `deleteBookmarksStart`

Each of these returns a `XDeleteTweetsStartResponse` object, which is this:

```ts
export type XDeleteTweetsStartResponse = {
    tweets: XTweetItem[];
}
```

Where `XTweetItem` is an object that includes details about the tweet, and also array of filenames for images and video embedded in the tweet:

```ts
export type XTweetItem = {
    id: string; // tweetID
    t: string; // text
    l: number; // likeCount
    r: number; // retweetCount
    d: string; // createdAt
    i: string[]; // image filenames
    v: string[]; // video filenames
}
```

These functions used to be implemented really badly. They would basically do this:

- Select all the rows from `tweet` that need to be deleted in (1 query)
- Loop through those rows, and for each row, select all the media from that tweet (another query), and all URLs from that tweet (yet another query)

So if you have 1000 tweets, that would be 2001 query (1 query to select the tweets, 1000 queries to select the media, and another 1000 queries to select the URLs). And if you have 100k tweets, that's 200k SQL queries.

I've refactored it so that it select the tweets, media, and URLs in just one SQL query. So if you have 100k tweets, it now makes 1 SQL query instead of 200k, lol.

## Use `INSERT OR REPLACE INTO` queries instead of separate `DELETE FROM` and `INSERT INTO` queries

I also believe this PR fixes #492, though I'm not entirely sure why that was happening to begin with.

But basically, all over the place, before inserting a row into the database, I'd make a query to see if that row already exists, and if it does, I'd do another query to delete it. Then, I'd do a query to insert it. All of this can be done with a single `INSERT OR REPLACE INTO` query.

So basically I updated it to change code like this:

```ts
// Have we seen this media before?
const existing: XTweetMediaRow[] = exec(this.db, 'SELECT * FROM tweet_media WHERE mediaID = ?', [media["media_key"]], "all") as XTweetMediaRow[];
if (existing.length > 0) {
    // Delete it, so we can re-add it
    exec(this.db, 'DELETE FROM tweet_media WHERE mediaID = ?', [media["media_key"]]);
}

// Index media information in tweet_media table
exec(this.db, 'INSERT INTO tweet_media (mediaID, mediaType, url, filename, startIndex, endIndex, tweetID) VALUES (?, ?, ?, ?, ?, ?, ?)', [
    media["media_key"],
    media["type"],
    media["url"],
    filename,
    media["indices"]?.[0],
    media["indices"]?.[1],
    tweetLegacy["id_str"],
]);
```

Into code like this:

```ts
// Index media information in tweet_media table
exec(this.db, 'INSERT OR REPLACE INTO tweet_media (mediaID, mediaType, url, filename, startIndex, endIndex, tweetID) VALUES (?, ?, ?, ?, ?, ?, ?)', [
    media["media_key"],
    media["type"],
    media["url"],
    filename,
    media["indices"]?.[0],
    media["indices"]?.[1],
    tweetLegacy["id_str"],
]);
```

This should fix #492 because `INSERT OR REPLACE INTO` shouldn't fail on unique constraint errors -- it should just replace the row.