### PR TITLE
Add scripts/make-linux-release.sh back

### DIFF
--- a/scripts/make-linux-release.sh
+++ b/scripts/make-linux-release.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+CYD_VERSION=$(cat package.json | grep '"version"' | cut -d'"' -f4)
+if [[ "$CYD_VERSION" == *-dev ]]; then
+    npm run make-dev
+else
+    npm run make-prod
+fi 


### PR DESCRIPTION
Oops. This was removed in #489, but now that we're making a release, it turns out it's necessary for linux,