### PR TITLE
Make graphqlGetViewerUser try 3 times

### DIFF
--- a/src/renderer/src/view_models/XViewModel.ts
+++ b/src/renderer/src/view_models/XViewModel.ts
@@ -276,6 +276,7 @@ export class XViewModel extends BaseViewModel {
     // Returns an XUserInfo object, or null on error
     async graphqlGetViewerUser(): Promise<XUserInfo | null> {
         this.log("graphqlGetViewerUser");
+
         const url = 'https://api.x.com/graphql/WBT8ommFCSHiy3z2_4k1Vg/Viewer?variables=%7B%22withCommunitiesMemberships%22%3Atrue%7D&features=%7B%22profile_label_improvements_pcf_label_in_post_enabled%22%3Atrue%2C%22rweb_tipjar_consumption_enabled%22%3Atrue%2C%22responsive_web_graphql_exclude_directive_enabled%22%3Atrue%2C%22verified_phone_label_enabled%22%3Afalse%2C%22creator_subscriptions_tweet_preview_api_enabled%22%3Atrue%2C%22responsive_web_graphql_skip_user_profile_image_extensions_enabled%22%3Afalse%2C%22responsive_web_graphql_timeline_navigation_enabled%22%3Atrue%7D&fieldToggles=%7B%22isDelegate%22%3Afalse%2C%22withAuxiliaryUserLabels%22%3Afalse%7D';
         const ct0 = await window.electron.X.getCookie(this.account.id, 'api.x.com', 'ct0');
 
@@ -284,60 +285,80 @@ export class XViewModel extends BaseViewModel {
             return null;
         }
 
-        const resp: string | null = await this.getWebview()?.executeJavaScript(`
-            (async () => {
-                const transactionID = [...crypto.getRandomValues(new Uint8Array(95))].map((x, i) => (i = x / 255 * 61 | 0, String.fromCharCode(i + (i > 9 ? i > 35 ? 61 : 55 : 48)))).join('');
-                try {
-                    const response = await fetch('${url}', {
-                        "headers": {
-                            "authorization": "${X_AUTHORIZATION_HEADER}",
-                            "content-type": "application/json",
-                            "x-client-transaction-id": transactionID,
-                            "x-csrf-token": '${ct0}',
-                            "x-twitter-client-language": "en",
-                            "x-twitter-active-user": "yes",
-                            "origin": 'https://x.com',
-                            "sec-fetch-site": "same-site",
-                            "sec-fetch-mode": "cors",
-                            "sec-fetch-dest": "empty"
-                        },
-                        "referrer": 'https://x.com/',
-                        "method": "GET",
-                        "mode": "cors",
-                        "credentials": "include",
-                        "signal": AbortSignal.timeout(5000)
-                    })
-                    if (response.status == 200) {
-                        return await response.text();
-                    }
-                    return null;
-                } catch (e) {
-                    return null;
-                }
-            })();
-        `);
+        // Give it 3 tries
+        let tries = 0;
+        while (tries < 3) {
+            if (tries > 0) {
+                // Sleep 1s before trying again
+                this.sleep(1000)
+            }
 
-        if (resp === null) {
-            this.log("graphqlGetViewerUser", "response is null");
-            return null;
-        } else {
-            try {
-                const viewerResults: XViewerResults = JSON.parse(resp);
-                const userInfo: XUserInfo = {
-                    username: viewerResults.data.viewer.user_results.result.legacy.screen_name,
-                    userID: viewerResults.data.viewer.user_results.result.rest_id,
-                    profileImageDataURI: await window.electron.X.getImageDataURI(this.account.id, viewerResults.data.viewer.user_results.result.legacy.profile_image_url_https),
-                    followingCount: viewerResults.data.viewer.user_results.result.legacy.friends_count,
-                    followersCount: viewerResults.data.viewer.user_results.result.legacy.followers_count,
-                    tweetsCount: viewerResults.data.viewer.user_results.result.legacy.statuses_count,
-                    likesCount: viewerResults.data.viewer.user_results.result.legacy.favourites_count,
-                };
-                return userInfo;
-            } catch (e) {
-                this.log("graphqlGetViewerUser", `error parsing response: ${resp}`);
-                return null;
+            this.log("graphqlGetViewerUser", `try #${tries}`);
+
+            // For reloading home
+            await this.loadURLWithRateLimit("https://x.com/home");
+
+            // Make the graphql request
+            const resp: string | null = await this.getWebview()?.executeJavaScript(`
+                (async () => {
+                    const transactionID = [...crypto.getRandomValues(new Uint8Array(95))].map((x, i) => (i = x / 255 * 61 | 0, String.fromCharCode(i + (i > 9 ? i > 35 ? 61 : 55 : 48)))).join('');
+                    try {
+                        const response = await fetch('${url}', {
+                            "headers": {
+                                "authorization": "${X_AUTHORIZATION_HEADER}",
+                                "content-type": "application/json",
+                                "x-client-transaction-id": transactionID,
+                                "x-csrf-token": '${ct0}',
+                                "x-twitter-client-language": "en",
+                                "x-twitter-active-user": "yes",
+                                "origin": 'https://x.com',
+                                "sec-fetch-site": "same-site",
+                                "sec-fetch-mode": "cors",
+                                "sec-fetch-dest": "empty"
+                            },
+                            "referrer": 'https://x.com/',
+                            "method": "GET",
+                            "mode": "cors",
+                            "credentials": "include",
+                            "signal": AbortSignal.timeout(5000)
+                        })
+                        if (response.status == 200) {
+                            return await response.text();
+                        }
+                        return null;
+                    } catch (e) {
+                        return null;
+                    }
+                })();
+            `);
+
+            if (resp === null) {
+                this.log("graphqlGetViewerUser", "response is null");
+                tries += 1;
+                continue;
+            } else {
+                try {
+                    const viewerResults: XViewerResults = JSON.parse(resp);
+                    const userInfo: XUserInfo = {
+                        username: viewerResults.data.viewer.user_results.result.legacy.screen_name,
+                        userID: viewerResults.data.viewer.user_results.result.rest_id,
+                        profileImageDataURI: await window.electron.X.getImageDataURI(this.account.id, viewerResults.data.viewer.user_results.result.legacy.profile_image_url_https),
+                        followingCount: viewerResults.data.viewer.user_results.result.legacy.friends_count,
+                        followersCount: viewerResults.data.viewer.user_results.result.legacy.followers_count,
+                        tweetsCount: viewerResults.data.viewer.user_results.result.legacy.statuses_count,
+                        likesCount: viewerResults.data.viewer.user_results.result.legacy.favourites_count,
+                    };
+                    return userInfo;
+                } catch (e) {
+                    this.log("graphqlGetViewerUser", `error parsing response: ${resp}`);
+                    tries += 1;
+                    continue;
+                }
             }
         }
+
+        this.log("graphqlGetViewerUser", 'failed to get userInfo after 3 tries');
+        return null;
     }
 
     async waitForRateLimit() {


### PR DESCRIPTION
Fixes #456. Or at least, I hope it should. It is not reliably reproducible.

The `XViewModel.login` function loads the login page and waits until the user is successfully logged in; then called `XViewModel.graphqlGetViewerUser` to get user info like username, user ID, profile image, etc.

The `graphqlGetViewerUser` function makes a GraphQL request. The error we're getting is sometimes this request fails and returns null. So this PR tries to make this more robust by:

- Trying 3 times instead of just once, waiting 1 second between tries
- Forcing a load of the X homepage before each try -- it only makes sense to make the GraphQL request from within the context of an X page that is fully loaded, so we make sure to fully load it each time
