### PR TITLE
Do not show old archive warning if no local DB in bluesky migrate

### DIFF
--- a/src/renderer/src/views/x/XWizardMigrateBluesky.vue
+++ b/src/renderer/src/views/x/XWizardMigrateBluesky.vue
@@ -135,8 +135,8 @@ const blueskyOAuthCallbackEventName = `blueskyOAuthCallback-${props.model.accoun
 const isArchiveOld = computed(() => {
     // The date before media was added to the Cyd archive, February 18, 2025
     const oldDate = new Date('2025-02-18T00:00:00Z');
-    return (lastImportArchive.value == null || lastImportArchive.value < oldDate) &&
-        (lastBuildDatabase.value == null || lastBuildDatabase.value < oldDate);
+    return (lastImportArchive.value === null || lastImportArchive.value < oldDate) &&
+        (lastBuildDatabase.value === null || lastBuildDatabase.value < oldDate);
 });
 
 onMounted(async () => {
@@ -184,7 +184,7 @@ onUnmounted(async () => {
                 old tweets.
             </p>
 
-            <div v-if="isArchiveOld" class="alert alert-warning">
+            <div v-if="isArchiveOld && hasSomeData" class="alert alert-warning">
                 <p>
                     <strong>
                         We recommend that you reimport your local database of tweets, or rebuild it from scratch,


### PR DESCRIPTION
Fixes #515 

Just adds a check that there is some data before showing the old data warning.
![Screenshot From 2025-05-08 16-19-25](https://github.com/user-attachments/assets/bc6bb064-3654-4b02-a5bf-3102bbb72733)
