### PR TITLE
Fix `GUEST_VIEW_MANAGER_CALL` error for good (I hope)

### DIFF
--- a/src/renderer/src/view_models/BaseViewModel.ts
+++ b/src/renderer/src/view_models/BaseViewModel.ts
@@ -287,6 +287,8 @@ export class BaseViewModel {
             await new Promise(resolve => setTimeout(resolve, 200));
             if (Date.now() - startTime >= timeout) {
                 this.log("waitForLoadingToFinish", "timeout reached while waiting for loading to finish");
+                // Force stop any navigation before returning
+                this.getWebview()?.stop();
                 return;
             }
         } while (this.getWebview()?.isLoading());
@@ -446,8 +448,7 @@ export class BaseViewModel {
         this.log("loadBlank");
         const webview = this.getWebview();
         if (webview) {
-            // Note: We need to wait for the page to finish loading before and after this to prevent
-            // Error: Error invoking remote method 'ELECTRON_GUEST_VIEW_MANAGER_CALL'
+            // Note: We need to wait for the page to finish loading before and after to prevent GUEST_VIEW_MANAGER_CALL
             // https://github.com/electron/electron/issues/24171#issuecomment-953053293
             await this.waitForLoadingToFinish();
             await webview.loadURL("about:blank")
@@ -458,6 +459,10 @@ export class BaseViewModel {
     async loadURL(url: string) {
         const webview = this.getWebview();
         if (webview) {
+            // Note: We need to wait for the page to finish loading before and after to prevent GUEST_VIEW_MANAGER_CALL
+            // https://github.com/electron/electron/issues/24171#issuecomment-953053293
+            await this.waitForLoadingToFinish();
+
             let tries = 0;
             // eslint-disable-next-line no-constant-condition
             while (true) {
@@ -492,6 +497,7 @@ export class BaseViewModel {
         } else {
             this.log("loadURL", "webview is null");
         }
+
         await this.waitForLoadingToFinish();
     }
 

--- a/src/renderer/src/view_models/XViewModel.ts
+++ b/src/renderer/src/view_models/XViewModel.ts
@@ -2862,7 +2862,7 @@ Hang on while I scroll down to your earliest bookmarks.`;
 
                 case State.WizardStart:
                     this.showBrowser = false;
-                    await this.loadURL("about:blank");
+                    await this.loadBlank();
 
                     // Make the user start where they last were
                     jobsType = getJobsType(this.account.id) || "";
@@ -2893,21 +2893,21 @@ Hang on while I scroll down to your earliest bookmarks.`;
 
 You can either import an X archive, or I can build it from scratch by scrolling through your profile.`;
                     this.state = State.WizardDatabaseDisplay;
-                    await this.loadURL("about:blank");
+                    await this.loadBlank();
                     break;
 
                 case State.WizardImportStart:
                     this.showBrowser = false;
                     this.instructions = `
 **Before you can import your X archive, you need to download it from X. Here's how.**`;
-                    await this.loadURL("about:blank");
+                    await this.loadBlank();
                     this.state = State.WizardImportStartDisplay;
                     break;
 
                 case State.WizardImportDownload:
                     this.showBrowser = false;
                     this.instructions = `You have requested your X archive, so now we wait.`;
-                    await this.loadURL("about:blank");
+                    await this.loadBlank();
                     this.state = State.WizardImportDownloadDisplay;
                     break;
 
@@ -2915,7 +2915,7 @@ You can either import an X archive, or I can build it from scratch by scrolling 
                     this.showBrowser = false;
                     this.instructions = `
 **I'll help you import your X archive into your local database.**`;
-                    await this.loadURL("about:blank");
+                    await this.loadBlank();
                     this.state = State.WizardImportingDisplay;
                     break;
 
@@ -2926,7 +2926,7 @@ I'll help you build a private local database of your X data to the \`Documents\`
 You'll be able to access it even after you delete it from X.
 
 **Which data do you want to save?**`;
-                    await this.loadURL("about:blank");
+                    await this.loadBlank();
                     this.state = State.WizardBuildOptionsDisplay;
                     break;
 
@@ -2938,7 +2938,7 @@ You'll be able to access it even after you delete it from X.
 - And I can also save a more detailed backup of your direct messages than is available in the official X archive.
 
 **Which data do you want to save?**`;
-                    await this.loadURL("about:blank");
+                    await this.loadBlank();
                     this.state = State.WizardArchiveOptionsDisplay;
                     break;
 
@@ -2946,7 +2946,7 @@ You'll be able to access it even after you delete it from X.
                     this.showBrowser = false;
                     this.instructions = `
 **Which data do you want to delete?**`;
-                    await this.loadURL("about:blank");
+                    await this.loadBlank();
                     this.state = State.WizardDeleteOptionsDisplay;
                     break;
 
@@ -2955,7 +2955,7 @@ You'll be able to access it even after you delete it from X.
                     this.instructions = `I'm almost ready to start helping you claw back your data from X!
 
 **Here's what I'm planning on doing.**`;
-                    await this.loadURL("about:blank");
+                    await this.loadBlank();
                     this.state = State.WizardReviewDisplay;
                     break;
 
@@ -2966,13 +2966,13 @@ You'll be able to access it even after you delete it from X.
                     if (databaseStatsString != "") {
                         this.instructions += `\n\nI've saved: **${await this.getDatabaseStatsString()}**.`
                     }
-                    await this.loadURL("about:blank");
+                    await this.loadBlank();
                     this.state = State.WizardDeleteReviewDisplay;
                     break;
 
                 case State.WizardMigrateToBluesky:
                     this.showBrowser = false;
-                    await this.loadURL("about:blank");
+                    await this.loadBlank();
                     this.instructions = `
 **Just because you're quitting X doesn't mean your posts need to disappear.**
 
@@ -2986,7 +2986,7 @@ After you build a local database of your tweets, I can help you migrate them int
 All done!
 
 **Here's what I did.**`;
-                    await this.loadURL("about:blank");
+                    await this.loadBlank();
                     this.state = State.FinishedRunningJobsDisplay;
                     break;
 
@@ -2995,7 +2995,7 @@ All done!
                     this.instructions = `**I'm almost ready to delete your data from X!**
 
 You can save all your data for free, but you need a Premium plan to delete your data.`;
-                    await this.loadURL("about:blank");
+                    await this.loadBlank();
                     this.state = State.WizardCheckPremiumDisplay;
                     break;
 
@@ -3029,13 +3029,13 @@ You can save all your data for free, but you need a Premium plan to delete your 
                     this.state = State.FinishedRunningJobs;
 
                     this.showBrowser = false;
-                    await this.loadURL("about:blank");
+                    await this.loadBlank();
                     break;
 
                 case State.Debug:
                     // Stay in this state until the user cancels it
                     this.showBrowser = false
-                    await this.loadURL("about:blank");
+                    await this.loadBlank();
                     this.instructions = `I'm in my debug state.`;
                     while (this.state === State.Debug) {
                         await this.sleep(1000);


### PR DESCRIPTION
Fixes #514.

The first bug report in #514 was bizarre because it occurred while loading `about:blank` and the state was `FinishedRunningJobs`. Why would this happen?

Here's the entire `FinishedRunningJobs` state, from `XViewModel`:

```ts
                case State.FinishedRunningJobs:
                    this.showBrowser = false;
                    this.instructions = `
All done!

**Here's what I did.**`;
                    await this.loadURL("about:blank");
                    this.state = State.FinishedRunningJobsDisplay;
                    break;
```

It sets the instruction, loads `about:blank`, and then switches the state to `FinishedRunningJobsDisplay`. So this must have occurred in this `loadURL` call.

So I looked in `BaseViewModel` for `loadURL` and noticed this:

```ts
    async loadBlank() {
        this.log("loadBlank");
        const webview = this.getWebview();
        if (webview) {
            // Note: We need to wait for the page to finish loading before and after this to prevent
            // Error: Error invoking remote method 'ELECTRON_GUEST_VIEW_MANAGER_CALL'
            // https://github.com/electron/electron/issues/24171#issuecomment-953053293
            await this.waitForLoadingToFinish();
            await webview.loadURL("about:blank")
            await this.waitForLoadingToFinish();
        }
    }

    async loadURL(url: string) {
        const webview = this.getWebview();
        if (webview) {
            let tries = 0;
            // eslint-disable-next-line no-constant-condition
            while (true) {
                try {
                    this.log("loadURL", `try #${tries}, ${url}`);
                    await webview.loadURL(url);
```

I had already implemented `loadBlank` (but we're not using it here), and I had also left a comment for that links here: https://github.com/electron/electron/issues/24171#issuecomment-953053293

That's a 5 year old bug, but I think it very likely has the same origins as this one. According to that bug, when you try called [`<webview>.loadURL`](https://www.electronjs.org/docs/latest/api/webview-tag#webviewloadurlurl-options) while the page is still loading, it fails with a `ELECTRON_GUEST_VIEW_MANAGER_CALL` error. (I'm guessing this is the same as the `GUEST_VIEW_MANAGER_CALL` error we're getting now, and it was just renamed at some point.)

The solution is to wait for the page to finish loading _before_ calling `webview.loadURL`, as well as after.

The `loadBlank` method already implemented this. So this PR does three things:

- Whenever we load `about:blank`, use `loadBlank` instead of `loadURL("about:blank")`
- `loadURL` is updated to wait for the page to finish loading _before_ it loads the URL
- `BaseViewModel.waitForLoadingToFinish` calls [`<webview>.isLoading()`](https://www.electronjs.org/docs/latest/api/webview-tag#webviewisloading) -- if it times out, it now explicitly calls [`<webview>.stop()`](https://www.electronjs.org/docs/latest/api/webview-tag#webviewstop) to force the navigation to stop, so that we know the page is not loading by the time the function returns