### PR TITLE
Fix migrating media in Bluesky

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "glob": "^11.0.3",
     "http-encoding": "^2.1.1",
     "http-mitm-proxy": "^1.1.0",
-    "image-size": "^2.0.2",
     "jsdom": "^26.1.0",
     "marked": "^16.1.2",
     "mhtml2html": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,9 +59,6 @@ importers:
       http-mitm-proxy:
         specifier: ^1.1.0
         version: 1.1.0
-      image-size:
-        specifier: ^2.0.2
-        version: 2.0.2
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0

--- a/src/account_x/x_account_controller.ts
+++ b/src/account_x/x_account_controller.ts
@@ -21,7 +21,6 @@ import {
 } from "@atproto/oauth-client-node";
 import { Agent, BlobRef, RichText } from "@atproto/api";
 import { Record as BskyPostRecord } from "@atproto/api/dist/client/types/app/bsky/feed/post";
-import { Link as BskyRichtextFacetLink } from "@atproto/api/dist/client/types/app/bsky/richtext/facet";
 
 import {
   getResourcesPath,
@@ -3145,13 +3144,8 @@ export class XAccountController {
 
     // Start building the tweet text and facets
     let text = tweet.text;
-    const facets: {
-      index: {
-        byteStart: number;
-        byteEnd: number;
-      };
-      features: BskyRichtextFacetLink[];
-    }[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const facets: any[] = [];
 
     // Replace t.co links with actual links
     let tweetURLs: XTweetURLRow[];
@@ -3259,7 +3253,8 @@ export class XAccountController {
     }
 
     // Handle quotes
-    let embed = null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let embed: any = null;
     if (tweet.isQuote && tweet.quotedTweet) {
       // Parse the quoted tweet URL to see if it's a self-quote
       // URL looks like: https://twitter.com/{username}/status/{tweetID}

--- a/src/account_x/x_account_controller.ts
+++ b/src/account_x/x_account_controller.ts
@@ -3468,7 +3468,8 @@ export class XAccountController {
         }
 
         // Determine the aspect ratio
-        const dimensions = sizeOf(mediaPath);
+        const imageBuffer = await fs.promises.readFile(mediaPath);
+        const dimensions = sizeOf(new Uint8Array(imageBuffer));
 
         // Upload the image
         log.info(

--- a/src/account_x/x_account_controller.ts
+++ b/src/account_x/x_account_controller.ts
@@ -5,7 +5,46 @@ import os from "os";
 import fetch from "node-fetch";
 import unzipper from "unzipper";
 import mime from "mime-types";
-import sizeOf from "image-size";
+
+// Simple image dimension reader for PNG and JPG
+async function getImageDimensions(
+  filePath: string,
+): Promise<{ width: number; height: number } | null> {
+  try {
+    const buffer = await fs.promises.readFile(filePath);
+
+    // PNG signature: 89 50 4E 47 0D 0A 1A 0A
+    if (
+      buffer[0] === 0x89 &&
+      buffer[1] === 0x50 &&
+      buffer[2] === 0x4e &&
+      buffer[3] === 0x47
+    ) {
+      // PNG: width and height are at bytes 16-19 and 20-23 (big-endian)
+      const width = buffer.readUInt32BE(16);
+      const height = buffer.readUInt32BE(20);
+      return { width, height };
+    }
+
+    // JPG/JPEG signature: FF D8
+    if (buffer[0] === 0xff && buffer[1] === 0xd8) {
+      // Scan for SOF0 (Start of Frame) marker: FF C0
+      for (let i = 2; i < buffer.length - 8; i++) {
+        if (buffer[i] === 0xff && buffer[i + 1] === 0xc0) {
+          // Height at offset 5-6, width at offset 7-8 (big-endian)
+          const height = buffer.readUInt16BE(i + 5);
+          const width = buffer.readUInt16BE(i + 7);
+          return { width, height };
+        }
+      }
+    }
+
+    return null;
+  } catch (error) {
+    log.error(`Error reading image dimensions: ${error}`);
+    return null;
+  }
+}
 
 import { app, session, shell } from "electron";
 import log from "electron-log/main";
@@ -3468,8 +3507,7 @@ export class XAccountController {
         }
 
         // Determine the aspect ratio
-        const imageBuffer = await fs.promises.readFile(mediaPath);
-        const dimensions = sizeOf(new Uint8Array(imageBuffer));
+        const dimensions = await getImageDimensions(mediaPath);
 
         // Upload the image
         log.info(
@@ -3486,8 +3524,8 @@ export class XAccountController {
           alt: "",
           image: resp.data.blob,
           aspectRatio: {
-            width: dimensions.width ? dimensions.width : 1,
-            height: dimensions.height ? dimensions.height : 1,
+            width: dimensions?.width || 1,
+            height: dimensions?.height || 1,
           },
         });
 


### PR DESCRIPTION
This fixes a few issues:

- There were some typescript warnings related to atproto types which are fixed.
- There was an error using the `image-size` module to get aspect ratios when migrating images. I've removed that dependency (yay one less dependency) and replaced it with a simple function that looks like dimensions for PNGs and JPGs.
- There was an error migrating videos. I'm not sure when this changed, but for some reason, mp4 video mime types were being reported as "application/mp4" but atproto requires the mime type to be "video/mp4". So I just made it use "video/mp4" if the mime type was "application/mp4", and that fixes it.
- When migrating a tweet with multiple animated gifs in it, this now only migrates the first animated gif. It's because 1) animated gifs in X are technically mp4 videos, not gifs, and 2) atproto only supports one video per post.