### PR TITLE
Use node 20 for building docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
           cache: "npm"
 
       - name: Install dependencies


### PR DESCRIPTION
I updated dependencies in docs, but it's failing to build and deploy in CI because it's doing it in node 18. This bumps it up to node 20.

Here's the failing job: https://github.com/lockdown-systems/cyd/actions/runs/19337660290/job/55317110114