### PR TITLE
Finish removing the docs package

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "appdmg": "^0.6.6"
   },
   "workspaces": [
-    "archive-static-sites/x-archive",
-    "docs"
+    "archive-static-sites/x-archive"
   ]
 }

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -27,9 +27,6 @@ if (fs.existsSync(buildDir)) {
 console.log("Running npm install for Cyd...");
 execSync("npm install", { stdio: "inherit" });
 
-console.log("Running npm install for docs...");
-execSync("npm install", { stdio: "inherit", cwd: "docs" });
-
 console.log("Running npm install for x-archive...");
 execSync("npm install", {
   stdio: "inherit",


### PR DESCRIPTION
When we migrated the docs into https://github.com/lockdown-systems/cyd-docs, there were still some remnants of them here, including one in `clean.mjs` which prevents making a release. This removes them.