### PR TITLE
Fix fb deletion priority

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "hasInstallScript": true,
       "license": "proprietary",
       "workspaces": [
-        "archive-static-sites/x-archive",
-        "docs"
+        "archive-static-sites/x-archive"
       ],
       "dependencies": {
         "@atproto/api": "^0.18.21",

--- a/src/account_facebook/controller/stats/getProgressInfo.ts
+++ b/src/account_facebook/controller/stats/getProgressInfo.ts
@@ -19,8 +19,25 @@ export async function getProgressInfo(
     totalWallPostsDeleted = parseInt(totalWallPostsDeletedConfig);
   }
 
+  const totalWallPostsUntaggedConfig: string | null =
+    await controller.getConfig("totalWallPostsUntagged");
+  let totalWallPostsUntagged: number = 0;
+  if (totalWallPostsUntaggedConfig) {
+    totalWallPostsUntagged = parseInt(totalWallPostsUntaggedConfig);
+  }
+
+  const totalWallPostsHiddenConfig: string | null = await controller.getConfig(
+    "totalWallPostsHidden",
+  );
+  let totalWallPostsHidden: number = 0;
+  if (totalWallPostsHiddenConfig) {
+    totalWallPostsHidden = parseInt(totalWallPostsHiddenConfig);
+  }
+
   const progressInfo = emptyFacebookProgressInfo();
   progressInfo.accountUUID = controller.accountUUID;
   progressInfo.totalWallPostsDeleted = totalWallPostsDeleted;
+  progressInfo.totalWallPostsUntagged = totalWallPostsUntagged;
+  progressInfo.totalWallPostsHidden = totalWallPostsHidden;
   return progressInfo;
 }

--- a/src/account_facebook/facebook_account_controller.ts
+++ b/src/account_facebook/facebook_account_controller.ts
@@ -222,4 +222,18 @@ export class FacebookAccountController extends BaseAccountController<FacebookPro
     const newValue = (currentValue ? parseInt(currentValue) : 0) + count;
     await this.setConfig("totalWallPostsDeleted", newValue.toString());
   }
+
+  // Increment the total wall posts untagged counter
+  async incrementTotalWallPostsUntagged(count: number): Promise<void> {
+    const currentValue = await this.getConfig("totalWallPostsUntagged");
+    const newValue = (currentValue ? parseInt(currentValue) : 0) + count;
+    await this.setConfig("totalWallPostsUntagged", newValue.toString());
+  }
+
+  // Increment the total wall posts hidden counter
+  async incrementTotalWallPostsHidden(count: number): Promise<void> {
+    const currentValue = await this.getConfig("totalWallPostsHidden");
+    const newValue = (currentValue ? parseInt(currentValue) : 0) + count;
+    await this.setConfig("totalWallPostsHidden", newValue.toString());
+  }
 }

--- a/src/account_facebook/ipc.ts
+++ b/src/account_facebook/ipc.ts
@@ -147,6 +147,30 @@ export const defineIPCFacebook = () => {
     },
   );
 
+  ipcMain.handle(
+    "Facebook:incrementTotalWallPostsUntagged",
+    async (_, accountID: number, count: number): Promise<void> => {
+      try {
+        const controller = getFacebookAccountController(accountID);
+        return await controller.incrementTotalWallPostsUntagged(count);
+      } catch (error) {
+        throw new Error(packageExceptionForReport(error as Error));
+      }
+    },
+  );
+
+  ipcMain.handle(
+    "Facebook:incrementTotalWallPostsHidden",
+    async (_, accountID: number, count: number): Promise<void> => {
+      try {
+        const controller = getFacebookAccountController(accountID);
+        return await controller.incrementTotalWallPostsHidden(count);
+      } catch (error) {
+        throw new Error(packageExceptionForReport(error as Error));
+      }
+    },
+  );
+
   ipcMain.handle("Facebook:isRateLimited", async (_, accountID: number) => {
     try {
       const controller = getFacebookAccountController(accountID);

--- a/src/cyd-api-client.ts
+++ b/src/cyd-api-client.ts
@@ -73,6 +73,8 @@ export type PostXProgressAPIRequest = {
 export type PostFacebookProgressAPIRequest = {
   account_uuid: string;
   total_wall_posts_deleted: number;
+  total_wall_posts_untagged: number;
+  total_wall_posts_hidden: number;
 };
 
 // API models for GET /user/premium

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -537,6 +537,26 @@ const electronAPI = {
         count,
       );
     },
+    incrementTotalWallPostsUntagged: (
+      accountID: number,
+      count: number,
+    ): Promise<void> => {
+      return ipcRenderer.invoke(
+        "Facebook:incrementTotalWallPostsUntagged",
+        accountID,
+        count,
+      );
+    },
+    incrementTotalWallPostsHidden: (
+      accountID: number,
+      count: number,
+    ): Promise<void> => {
+      return ipcRenderer.invoke(
+        "Facebook:incrementTotalWallPostsHidden",
+        accountID,
+        count,
+      );
+    },
     isRateLimited: (accountID: number): Promise<FacebookRateLimitInfo> => {
       return ipcRenderer.invoke("Facebook:isRateLimited", accountID);
     },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -407,12 +407,12 @@
       "getArchiveTitle": "Get Archive from Meta",
       "getArchiveDescription": "If you want, export your Facebook archive BEFORE you delete all your posts.",
       "deleteWallTitle": "Delete My Wall",
-      "deleteWallDescription": "Delete all posts from your Facebook wall."
+      "deleteWallDescription": "Remove all posts from your Facebook wall."
     },
     "deleteOptions": {
       "title": "Delete My Wall",
-      "description": "Select the data you want to delete from your Facebook wall.",
-      "deleteWallPosts": "Delete all posts from my wall"
+      "description": "Select the data you want to remove from your Facebook wall.",
+      "deleteWallPosts": "Remove all posts from my wall"
     },
     "review": {
       "deleteWallPosts": "All posts from your Facebook wall",
@@ -421,7 +421,9 @@
     },
     "finished": {
       "title": "Jobs Completed",
-      "wallPosts": "wall posts removed (deleted, untagged, or hidden)"
+      "wallPostsDeleted": "wall posts deleted",
+      "wallPostsUntagged": "wall posts untagged",
+      "wallPostsHidden": "wall posts hidden"
     },
     "premium": {
       "readyToDelete": "You're all set! Let's continue to configure what you want to delete.",
@@ -631,7 +633,9 @@
         "actionHidePresent": "hiding"
       },
       "progress": {
-        "wallPostsDeleted": "Removed {count} wall posts."
+        "wallPostsDeleted": "Deleted {count} wall posts.",
+        "wallPostsUntagged": "Untagged {count} wall posts.",
+        "wallPostsHidden": "Hidden {count} wall posts."
       }
     }
   }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -622,7 +622,13 @@
         "restoringLanguage": "I'm restoring your original language setting.",
         "removingWallPosts": "# I'm removing all posts from your Facebook wall.",
         "checkBatchActionWallPosts": "# I'm looking for a batch of posts to {action}...",
-        "removeActionWallPosts": "# I'm going to {action} {count} posts...."
+        "removeActionWallPosts": "# I'm {action} {count} posts....",
+        "actionDelete": "delete",
+        "actionDeletePresent": "deleting",
+        "actionUntag": "untag",
+        "actionUntagPresent": "untagging",
+        "actionHide": "hide",
+        "actionHidePresent": "hiding"
       },
       "progress": {
         "wallPostsDeleted": "Removed {count} wall posts."

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -623,6 +623,7 @@
         "settingLanguageToEnglish": "I'm temporarily changing your language to English (US) for automation.",
         "restoringLanguage": "I'm restoring your original language setting.",
         "removingWallPosts": "# I'm removing all posts from your Facebook wall.",
+        "managePostsLoading": "# I'm checking what posts are left to remove.",
         "checkBatchActionWallPosts": "# I'm looking for a batch of posts to **{action}**...",
         "removeActionWallPosts": "# I'm **{action} {count} posts**....",
         "actionDelete": "delete",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -620,7 +620,9 @@
         "savingLanguage": "I'm checking your language settings.",
         "settingLanguageToEnglish": "I'm temporarily changing your language to English (US) for automation.",
         "restoringLanguage": "I'm restoring your original language setting.",
-        "deletingWallPosts": "# I'm removing all posts from your Facebook wall."
+        "removingWallPosts": "# I'm removing all posts from your Facebook wall.",
+        "checkBatchActionWallPosts": "# I'm looking for a batch of posts to {action}...",
+        "removeActionWallPosts": "# I'm going to {action} {count} posts...."
       },
       "progress": {
         "wallPostsDeleted": "Removed {count} wall posts."

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -44,7 +44,7 @@
     "tombstoneLockAccount": "Locking account",
     "savePosts": "Saving posts",
     "savePostsHTML": "Saving posts HTML",
-    "deleteWallPosts": "Deleting wall posts",
+    "deleteWallPosts": "Removing wall posts",
     "restoreUserLang": "Restoring language"
   },
   "progress": {
@@ -623,8 +623,8 @@
         "settingLanguageToEnglish": "I'm temporarily changing your language to English (US) for automation.",
         "restoringLanguage": "I'm restoring your original language setting.",
         "removingWallPosts": "# I'm removing all posts from your Facebook wall.",
-        "checkBatchActionWallPosts": "# I'm looking for a batch of posts to {action}...",
-        "removeActionWallPosts": "# I'm {action} {count} posts....",
+        "checkBatchActionWallPosts": "# I'm looking for a batch of posts to **{action}**...",
+        "removeActionWallPosts": "# I'm **{action} {count} posts**....",
         "actionDelete": "delete",
         "actionDeletePresent": "deleting",
         "actionUntag": "untag",
@@ -633,9 +633,7 @@
         "actionHidePresent": "hiding"
       },
       "progress": {
-        "wallPostsDeleted": "Deleted {count} wall posts.",
-        "wallPostsUntagged": "Untagged {count} wall posts.",
-        "wallPostsHidden": "Hidden {count} wall posts."
+        "wallPostsProgress": "Deleted **{deleteCount}**, untagged **{untagCount}**, and hid **{hideCount}** wall posts."
       }
     }
   }

--- a/src/renderer/src/test_util.ts
+++ b/src/renderer/src/test_util.ts
@@ -308,12 +308,16 @@ export function mockElectronAPI() {
       getProgressInfo: vi.fn().mockResolvedValue({
         accountUUID: "test-uuid-123",
         totalWallPostsDeleted: 0,
+        totalWallPostsUntagged: 0,
+        totalWallPostsHidden: 0,
       }),
       getConfig: vi.fn().mockResolvedValue(null),
       setConfig: vi.fn().mockResolvedValue(undefined),
       deleteConfig: vi.fn().mockResolvedValue(undefined),
       deleteConfigLike: vi.fn().mockResolvedValue(undefined),
       incrementTotalWallPostsDeleted: vi.fn().mockResolvedValue(undefined),
+      incrementTotalWallPostsUntagged: vi.fn().mockResolvedValue(undefined),
+      incrementTotalWallPostsHidden: vi.fn().mockResolvedValue(undefined),
       isRateLimited: vi
         .fn()
         .mockResolvedValue({ isRateLimited: false, rateLimitReset: 0 }),

--- a/src/renderer/src/util_facebook.test.ts
+++ b/src/renderer/src/util_facebook.test.ts
@@ -60,6 +60,8 @@ describe("util_facebook", () => {
       const mockProgressInfo = {
         accountUUID: "test-uuid-123",
         totalWallPostsDeleted: 42,
+        totalWallPostsUntagged: 0,
+        totalWallPostsHidden: 0,
       };
       mockFacebookGetProgressInfo.mockResolvedValue(mockProgressInfo);
 
@@ -79,6 +81,8 @@ describe("util_facebook", () => {
         {
           account_uuid: "test-uuid-123",
           total_wall_posts_deleted: 42,
+          total_wall_posts_untagged: 0,
+          total_wall_posts_hidden: 0,
         },
         true,
       );
@@ -93,6 +97,8 @@ describe("util_facebook", () => {
       const mockProgressInfo = {
         accountUUID: "test-uuid-456",
         totalWallPostsDeleted: 100,
+        totalWallPostsUntagged: 0,
+        totalWallPostsHidden: 0,
       };
       mockFacebookGetProgressInfo.mockResolvedValue(mockProgressInfo);
 
@@ -111,6 +117,8 @@ describe("util_facebook", () => {
         {
           account_uuid: "test-uuid-456",
           total_wall_posts_deleted: 100,
+          total_wall_posts_untagged: 0,
+          total_wall_posts_hidden: 0,
         },
         false,
       );
@@ -125,6 +133,8 @@ describe("util_facebook", () => {
       const mockProgressInfo = {
         accountUUID: "test-uuid-789",
         totalWallPostsDeleted: 0,
+        totalWallPostsUntagged: 0,
+        totalWallPostsHidden: 0,
       };
       mockFacebookGetProgressInfo.mockResolvedValue(mockProgressInfo);
 
@@ -134,6 +144,8 @@ describe("util_facebook", () => {
         {
           account_uuid: "test-uuid-789",
           total_wall_posts_deleted: 0,
+          total_wall_posts_untagged: 0,
+          total_wall_posts_hidden: 0,
         },
         false,
       );
@@ -154,6 +166,8 @@ describe("util_facebook", () => {
       const mockProgressInfo = {
         accountUUID: "test-uuid",
         totalWallPostsDeleted: 10,
+        totalWallPostsUntagged: 0,
+        totalWallPostsHidden: 0,
       };
       mockFacebookGetProgressInfo.mockResolvedValue(mockProgressInfo);
 

--- a/src/renderer/src/util_facebook.ts
+++ b/src/renderer/src/util_facebook.ts
@@ -13,6 +13,8 @@ export async function facebookPostProgress(
     {
       account_uuid: progressInfo.accountUUID,
       total_wall_posts_deleted: progressInfo.totalWallPostsDeleted,
+      total_wall_posts_untagged: progressInfo.totalWallPostsUntagged,
+      total_wall_posts_hidden: progressInfo.totalWallPostsHidden,
     },
     deviceInfo?.valid ? true : false,
   );

--- a/src/renderer/src/view_models/FacebookViewModel/jobs_delete.test.ts
+++ b/src/renderer/src/view_models/FacebookViewModel/jobs_delete.test.ts
@@ -686,7 +686,7 @@ describe("FacebookViewModel Delete Jobs", () => {
         "runJobDeleteWallPosts",
         'Item keeps batch action "untag", checked 1/10',
       );
-      expect(vm.progress.wallPostsDeleted).toBe(1);
+      expect(vm.progress.wallPostsUntagged).toBe(1);
     });
 
     it("unchecks the last item before clicking Next when delete is no longer allowed", async () => {

--- a/src/renderer/src/view_models/FacebookViewModel/jobs_delete.test.ts
+++ b/src/renderer/src/view_models/FacebookViewModel/jobs_delete.test.ts
@@ -190,6 +190,9 @@ describe("FacebookViewModel Delete Jobs", () => {
       vi.mocked(mockWebview.executeJavaScript)
         .mockResolvedValueOnce(true) // clickManagePostsButton
         .mockResolvedValueOnce(true) // waitForManagePostsDialog (first check)
+        .mockResolvedValue([])
+        .mockResolvedValueOnce(true) // clickManagePostsButton
+        .mockResolvedValueOnce(true) // waitForManagePostsDialog (first check)
         .mockResolvedValue([]); // getListsAndItems returns empty
 
       await DeleteJobs.runJobDeleteWallPosts(vm, 3);
@@ -556,7 +559,7 @@ describe("FacebookViewModel Delete Jobs", () => {
 
       expect(vm.log).toHaveBeenCalledWith(
         "runJobDeleteWallPosts",
-        'First item sets batch action to "untag", checked 1/10',
+        'Item keeps batch action "untag", checked 1/10',
       );
       expect(vm.progress.wallPostsDeleted).toBe(1);
     });

--- a/src/renderer/src/view_models/FacebookViewModel/jobs_delete.test.ts
+++ b/src/renderer/src/view_models/FacebookViewModel/jobs_delete.test.ts
@@ -468,6 +468,131 @@ describe("FacebookViewModel Delete Jobs", () => {
       expect(vm.progress.wallPostsDeleted).toBe(1);
     });
 
+    it("deletes second item even if first item is hide and second item is delete", async () => {
+      // Items: item 0 supports hide, item 1 supports delete+hide only.
+      // Expected: check item 0 (priority=hide) -> uncheck, check item 1 -> priority=delete.
+      // Then proceed to delete item 1. On 2nd batch, clickManagePostsButton fails -> exit.
+      const vm = createMockFacebookViewModel();
+      const mockWebview = vm.getWebview()!;
+
+      let managePostsClicks = 0;
+      let isDialogOpen = false;
+      let isActionOptionsVisible = false;
+      const checkedItems = new Set<string>();
+
+      vi.mocked(mockWebview.executeJavaScript).mockImplementation(
+        async (code: string) => {
+          if (
+            code.includes(
+              `querySelectorAll('div[aria-label="Manage posts"][role="button"]')`,
+            )
+          ) {
+            managePostsClicks++;
+            isDialogOpen = managePostsClicks === 1;
+            isActionOptionsVisible = false;
+            return managePostsClicks <= 2;
+          }
+
+          if (
+            code.includes(
+              `document.querySelector('div[aria-label="Manage posts"][role="dialog"]')`,
+            ) &&
+            code.includes("return !!dialog;")
+          ) {
+            return isDialogOpen;
+          }
+
+          if (code.includes("result.push({ listIndex, itemIndex });")) {
+            return managePostsClicks === 1
+              ? [
+                  { listIndex: 0, itemIndex: 0 },
+                  { listIndex: 0, itemIndex: 1 },
+                ]
+              : [];
+          }
+
+          if (code.includes("const shouldCheck = ")) {
+            const listMatch = code.match(/const list = lists\[(\d+)\];/);
+            const itemMatch = code.match(/const item = items\[(\d+)\];/);
+            const shouldCheckMatch = code.match(
+              /const shouldCheck = (true|false);/,
+            );
+
+            if (!listMatch || !itemMatch || !shouldCheckMatch) {
+              return false;
+            }
+
+            const key = `${listMatch[1]}-${itemMatch[1]}`;
+            const shouldCheck = shouldCheckMatch[1] === "true";
+
+            if (shouldCheck) {
+              checkedItems.add(key);
+            } else {
+              checkedItems.delete(key);
+            }
+
+            return true;
+          }
+
+          if (code.includes("checkbox instanceof HTMLInputElement")) {
+            const listMatch = code.match(/const list = lists\[(\d+)\];/);
+            const itemMatch = code.match(/const item = items\[(\d+)\];/);
+
+            if (!listMatch || !itemMatch) {
+              return null;
+            }
+
+            return checkedItems.has(`${listMatch[1]}-${itemMatch[1]}`);
+          }
+
+          if (code.includes('text.startsWith("You can")')) {
+            if (checkedItems.has("0-0") && !checkedItems.has("0-1")) {
+              return "You can hide the posts selected.";
+            }
+
+            if (!checkedItems.has("0-0") && checkedItems.has("0-1")) {
+              // Unchecked hide item but checked the deleteable item
+              return "You can hide or delete the posts selected.";
+            }
+
+            return "";
+          }
+
+          if (code.includes(`aria-label="Next"`)) {
+            isActionOptionsVisible = true;
+            return true;
+          }
+
+          if (
+            code.includes("const hasActionOptions =") &&
+            code.includes(`aria-label="Done"`)
+          ) {
+            return isActionOptionsVisible;
+          }
+
+          if (code.includes("text.includes('delete posts')")) {
+            return checkedItems.size === 1 && checkedItems.has("0-1");
+          }
+
+          if (code.includes(`aria-label="Done"`)) {
+            isDialogOpen = false;
+            isActionOptionsVisible = false;
+            return true;
+          }
+
+          return false;
+        },
+      );
+
+      await DeleteJobs.runJobDeleteWallPosts(vm, 3);
+
+      expect(vm.log).toHaveBeenCalledWith(
+        "runJobDeleteWallPosts",
+        expect.stringContaining('Selected 1 items for action "delete"'),
+      );
+      expect(vm.progress.wallPostsDeleted).toBe(1);
+    });
+
     it("performs untag action when highest priority is untag", async () => {
       // Item supports untag+hide. Expected: batch action = untag.
       // On 2nd batch, clickManagePostsButton fails -> exit.

--- a/src/renderer/src/view_models/FacebookViewModel/jobs_delete.ts
+++ b/src/renderer/src/view_models/FacebookViewModel/jobs_delete.ts
@@ -418,7 +418,7 @@ async function selectDeletePostsOption(
 
       // Find all divs that might contain the delete posts option
       const divs = dialog.querySelectorAll('div[aria-disabled]');
-      
+
       for (const div of divs) {
         // Check if this div or its children contain text about deleting posts
         const text = div.textContent?.toLowerCase() || '';
@@ -437,7 +437,7 @@ async function selectDeletePostsOption(
           }
         }
       }
-      
+
       console.log('Could not find delete posts option');
       return false;
     })()`,
@@ -640,62 +640,63 @@ export async function runJobDeleteWallPosts(
     );
 
     let checkedCount = 0;
-    let batchAction: PostAction | null = null;
+    const batchActions: PostAction[] = ["delete", "untag", "hide"] // Check all actions in priority order
+    let batchAction: PostAction = "delete";
 
-    // Loop through items, checking each one. Track the highest-priority action
-    // available for all checked items. Stop when adding a new item would reduce
-    // the priority (e.g. from delete -> hide).
-    for (const { listIndex, itemIndex } of allItems) {
-      // Check for rate limits
-      await checkRateLimit(vm);
+    // infinite loop to loop through different actions
+    for (const action of batchActions) {
+      batchAction = action
+      // Loop through items, checking if any item match the current batchAction priority action.
+      // Stop when adding a new item would reduce the priority (e.g. from delete -> hide).
+      for (const { listIndex, itemIndex } of allItems) {
+        // Check for rate limits
+        await checkRateLimit(vm);
 
-      if (checkedCount >= maxToCheck) {
+        if (checkedCount >= maxToCheck) {
+          vm.log(
+            "runJobDeleteWallPosts",
+            `Reached maximum of ${maxToCheck} items`,
+          );
+          break;
+        }
+
+        await vm.waitForPause();
+
+        // Check this checkbox
+        const toggled = await toggleCheckbox(vm, listIndex, itemIndex, true);
+        if (!toggled) {
+          vm.log(
+            "runJobDeleteWallPosts",
+            `Failed to check item [${listIndex}][${itemIndex}]`,
+          );
+          continue;
+        }
+
+        const checkboxChecked = await waitForCheckboxState(
+          vm,
+          listIndex,
+          itemIndex,
+          true,
+        );
+        if (!checkboxChecked) {
+          vm.log(
+            "runJobDeleteWallPosts",
+            `Timed out waiting for item [${listIndex}][${itemIndex}] to become checked`,
+          );
+          continue;
+        }
+
+        // Read the combined action description (reflects all currently-checked items)
+        const actionDescription = await waitForActionDescriptionStable(vm);
         vm.log(
           "runJobDeleteWallPosts",
-          `Reached maximum of ${maxToCheck} items`,
+          `Action description: "${actionDescription}"`,
         );
-        break;
-      }
 
-      await vm.waitForPause();
-
-      // Check this checkbox
-      const toggled = await toggleCheckbox(vm, listIndex, itemIndex, true);
-      if (!toggled) {
-        vm.log(
-          "runJobDeleteWallPosts",
-          `Failed to check item [${listIndex}][${itemIndex}]`,
+        const combinedPriority = getHighestPriority(
+          parseActions(actionDescription),
         );
-        continue;
-      }
 
-      const checkboxChecked = await waitForCheckboxState(
-        vm,
-        listIndex,
-        itemIndex,
-        true,
-      );
-      if (!checkboxChecked) {
-        vm.log(
-          "runJobDeleteWallPosts",
-          `Timed out waiting for item [${listIndex}][${itemIndex}] to become checked`,
-        );
-        continue;
-      }
-
-      // Read the combined action description (reflects all currently-checked items)
-      const actionDescription = await waitForActionDescriptionStable(vm);
-      vm.log(
-        "runJobDeleteWallPosts",
-        `Action description: "${actionDescription}"`,
-      );
-
-      const combinedPriority = getHighestPriority(
-        parseActions(actionDescription),
-      );
-
-      if (batchAction === null) {
-        // First item: establish the batch action
         if (combinedPriority === null) {
           // Unrecognized description, skip this item
           vm.log(
@@ -705,74 +706,74 @@ export async function runJobDeleteWallPosts(
           await toggleCheckbox(vm, listIndex, itemIndex, false);
           await waitForCheckboxState(vm, listIndex, itemIndex, false);
           continue;
-        }
-        batchAction = combinedPriority;
-        checkedCount++;
-        vm.log(
-          "runJobDeleteWallPosts",
-          `First item sets batch action to "${batchAction}", checked ${checkedCount}/${maxToCheck}`,
-        );
-      } else if (combinedPriority === batchAction) {
-        // Same priority: keep this item checked and continue
-        checkedCount++;
-        vm.log(
-          "runJobDeleteWallPosts",
-          `Item keeps batch action "${batchAction}", checked ${checkedCount}/${maxToCheck}`,
-        );
-      } else {
-        // Adding this item changes the priority — uncheck it and stop
-        vm.log(
-          "runJobDeleteWallPosts",
-          `Item [${listIndex}][${itemIndex}] changes priority from "${batchAction}" to "${combinedPriority}", unchecking and stopping`,
-        );
-        await toggleCheckbox(vm, listIndex, itemIndex, false);
-        const checkboxUnchecked = await waitForCheckboxState(
-          vm,
-          listIndex,
-          itemIndex,
-          false,
-        );
-        if (!checkboxUnchecked) {
+        } else if (combinedPriority === batchAction) {
+          // Same priority: keep this item checked and continue
+          checkedCount++;
           vm.log(
             "runJobDeleteWallPosts",
-            `Timed out waiting for item [${listIndex}][${itemIndex}] to become unchecked`,
+            `Item keeps batch action "${batchAction}", checked ${checkedCount}/${maxToCheck}`,
           );
-        }
-
-        const batchActionRestored = await waitForBatchAction(vm, batchAction);
-        if (!batchActionRestored.success) {
-          await reportDeleteWallPostsError(
+        } else {
+          // Adding this item changes the priority — uncheck it and stop
+          vm.log(
+            "runJobDeleteWallPosts",
+            `Item [${listIndex}][${itemIndex}] changes priority from "${batchAction}" to "${combinedPriority}", unchecking and stopping`,
+          );
+          await toggleCheckbox(vm, listIndex, itemIndex, false);
+          const checkboxUnchecked = await waitForCheckboxState(
             vm,
-            jobIndex,
-            AutomationErrorType.facebook_runJob_deleteWallPosts_SelectDeleteOptionFailed,
-            {
-              batchNumber,
-              message: `Batch action did not return to "${batchAction}" after unchecking item [${listIndex}][${itemIndex}]`,
-              actionDescription: batchActionRestored.actionDescription,
-            },
+            listIndex,
+            itemIndex,
+            false,
           );
-          return;
+          if (!checkboxUnchecked) {
+            vm.log(
+              "runJobDeleteWallPosts",
+              `Timed out waiting for item [${listIndex}][${itemIndex}] to become unchecked`,
+            );
+          }
+
+          const batchActionRestored = await waitForBatchAction(vm, batchAction);
+          if (!batchActionRestored.success && checkedCount !== 0) {
+            await reportDeleteWallPostsError(
+              vm,
+              jobIndex,
+              AutomationErrorType.facebook_runJob_deleteWallPosts_SelectDeleteOptionFailed,
+              {
+                batchNumber,
+                message: `Batch action did not return to "${batchAction}" after unchecking item [${listIndex}][${itemIndex}]`,
+                actionDescription: batchActionRestored.actionDescription,
+              },
+            );
+            return;
+          }
+          break;
         }
+      }
+
+      vm.log(
+        "runJobDeleteWallPosts",
+        `Selected ${checkedCount} items for action "${batchAction}"`,
+      );
+
+      if (checkedCount !== 0) {
+        // If actionable items found, no need to loop through other actions
         break;
+      }
+
+      // If nothing was checked, see if more items get selected by next priority action in the list
+      if (batchAction !== "hide") {
+        vm.log(
+          "runJobDeleteWallPosts",
+          `No actionable items found for action "${batchAction}", checking next priority action`
+        )
       }
     }
 
-    vm.log(
-      "runJobDeleteWallPosts",
-      `Selected ${checkedCount} items for action "${batchAction}"`,
-    );
-
-    // If nothing was checked, we're done
-    if (checkedCount === 0) {
+    if (checkedCount === 0 && batchAction === "hide") {
+      // If the current action is hide and still checked item is 0, means all priority actions have
+      // been checked and nothing left to do.
       vm.log("runJobDeleteWallPosts", "No actionable items found, finishing");
-      break;
-    }
-
-    if (batchAction === null) {
-      vm.log(
-        "runJobDeleteWallPosts",
-        "Checked items were selected but no batch action was determined",
-      );
       break;
     }
 

--- a/src/renderer/src/view_models/FacebookViewModel/jobs_delete.ts
+++ b/src/renderer/src/view_models/FacebookViewModel/jobs_delete.ts
@@ -640,12 +640,12 @@ export async function runJobDeleteWallPosts(
     );
 
     let checkedCount = 0;
-    const batchActions: PostAction[] = ["delete", "untag", "hide"] // Check all actions in priority order
+    const batchActions: PostAction[] = ["delete", "untag", "hide"]; // Check all actions in priority order
     let batchAction: PostAction = "delete";
 
     // infinite loop to loop through different actions
     for (const action of batchActions) {
-      batchAction = action
+      batchAction = action;
       // Loop through items, checking if any item match the current batchAction priority action.
       // Stop when adding a new item would reduce the priority (e.g. from delete -> hide).
       for (const { listIndex, itemIndex } of allItems) {
@@ -714,10 +714,10 @@ export async function runJobDeleteWallPosts(
             `Item keeps batch action "${batchAction}", checked ${checkedCount}/${maxToCheck}`,
           );
         } else {
-          // Adding this item changes the priority — uncheck it and stop
+          // Adding this item changes the priority — uncheck it and go to next item
           vm.log(
             "runJobDeleteWallPosts",
-            `Item [${listIndex}][${itemIndex}] changes priority from "${batchAction}" to "${combinedPriority}", unchecking and stopping`,
+            `Item [${listIndex}][${itemIndex}] changes priority from "${batchAction}" to "${combinedPriority}", unchecking`,
           );
           await toggleCheckbox(vm, listIndex, itemIndex, false);
           const checkboxUnchecked = await waitForCheckboxState(
@@ -747,7 +747,7 @@ export async function runJobDeleteWallPosts(
             );
             return;
           }
-          break;
+          continue;
         }
       }
 
@@ -765,8 +765,8 @@ export async function runJobDeleteWallPosts(
       if (batchAction !== "hide") {
         vm.log(
           "runJobDeleteWallPosts",
-          `No actionable items found for action "${batchAction}", checking next priority action`
-        )
+          `No actionable items found for action "${batchAction}", checking next priority action`,
+        );
       }
     }
 

--- a/src/renderer/src/view_models/FacebookViewModel/jobs_delete.ts
+++ b/src/renderer/src/view_models/FacebookViewModel/jobs_delete.ts
@@ -657,7 +657,7 @@ export async function runJobDeleteWallPosts(
     const batchActions: PostAction[] = ["delete", "untag", "hide"]; // Check all actions in priority order
     let batchAction: PostAction = "delete";
 
-    // infinite loop to loop through different actions
+    // loop through different actions
     for (const action of batchActions) {
       batchAction = action;
       vm.instructions = vm.t(
@@ -969,6 +969,7 @@ export async function runJobDeleteWallPosts(
 
     // Reload the profile page to see any newly available posts
     vm.log("runJobDeleteWallPosts", "Reloading profile page for next batch");
+    vm.instructions = vm.t("viewModels.facebook.jobs.managePostsLoading");
     await vm.loadURL(FACEBOOK_PROFILE_URL);
     await vm.waitForLoadingToFinish();
   }

--- a/src/renderer/src/view_models/FacebookViewModel/jobs_delete.ts
+++ b/src/renderer/src/view_models/FacebookViewModel/jobs_delete.ts
@@ -545,7 +545,7 @@ export async function runJobDeleteWallPosts(
 
   vm.showBrowser = true;
   vm.showAutomationNotice = true;
-  vm.instructions = vm.t("viewModels.facebook.jobs.deletingWallPosts");
+  vm.instructions = vm.t("viewModels.facebook.jobs.removingWallPosts");
 
   vm.log("runJobDeleteWallPosts", "Loading profile page");
 
@@ -646,6 +646,9 @@ export async function runJobDeleteWallPosts(
     // infinite loop to loop through different actions
     for (const action of batchActions) {
       batchAction = action;
+      vm.instructions = vm.t("viewModels.facebook.jobs.checkBatchActionWallPosts", {
+        action: batchAction,
+      });
       // Loop through items, checking if any item match the current batchAction priority action.
       // Stop when adding a new item would reduce the priority (e.g. from delete -> hide).
       for (const { listIndex, itemIndex } of allItems) {
@@ -758,6 +761,10 @@ export async function runJobDeleteWallPosts(
 
       if (checkedCount !== 0) {
         // If actionable items found, no need to loop through other actions
+        vm.instructions = vm.t("viewModels.facebook.jobs.removeActionWallPosts", {
+          action: batchAction,
+          count: checkedCount,
+        });
         break;
       }
 

--- a/src/renderer/src/view_models/FacebookViewModel/jobs_delete.ts
+++ b/src/renderer/src/view_models/FacebookViewModel/jobs_delete.ts
@@ -571,6 +571,8 @@ export async function runJobDeleteWallPosts(
 
   // Keep deleting posts until there are no more to delete
   let totalDeleted = 0;
+  let totalUntagged = 0;
+  let totalHidden = 0;
   let batchNumber = 0;
   const maxToCheck = 10;
 
@@ -923,18 +925,38 @@ export async function runJobDeleteWallPosts(
     }
 
     // Update progress
-    totalDeleted += checkedCount;
-    vm.progress.wallPostsDeleted = totalDeleted;
+    if (batchAction === "delete") {
+      totalDeleted += checkedCount;
+      vm.progress.wallPostsDeleted = totalDeleted;
+    } else if (batchAction === "untag") {
+      totalUntagged += checkedCount;
+      vm.progress.wallPostsUntagged = totalUntagged;
+    } else {
+      totalHidden += checkedCount;
+      vm.progress.wallPostsHidden = totalHidden;
+    }
     vm.log(
       "runJobDeleteWallPosts",
-      `Batch ${batchNumber} complete: deleted ${checkedCount} posts, total: ${totalDeleted}`,
+      `Batch ${batchNumber} complete: ${batchAction} ${checkedCount} posts (deleted: ${totalDeleted}, untagged: ${totalUntagged}, hidden: ${totalHidden})`,
     );
 
     // Update the persistent counter in the database
-    await window.electron.Facebook.incrementTotalWallPostsDeleted(
-      vm.account.id,
-      checkedCount,
-    );
+    if (batchAction === "delete") {
+      await window.electron.Facebook.incrementTotalWallPostsDeleted(
+        vm.account.id,
+        checkedCount,
+      );
+    } else if (batchAction === "untag") {
+      await window.electron.Facebook.incrementTotalWallPostsUntagged(
+        vm.account.id,
+        checkedCount,
+      );
+    } else {
+      await window.electron.Facebook.incrementTotalWallPostsHidden(
+        vm.account.id,
+        checkedCount,
+      );
+    }
 
     // Submit progress to the API
     vm.emitter?.emit(`facebook-submit-progress-${vm.account.id}`);

--- a/src/renderer/src/view_models/FacebookViewModel/jobs_delete.ts
+++ b/src/renderer/src/view_models/FacebookViewModel/jobs_delete.ts
@@ -130,6 +130,18 @@ async function getActionDescription(vm: FacebookViewModel): Promise<string> {
 
 type PostAction = "delete" | "untag" | "hide";
 
+const actionVerbKeys: Record<PostAction, string> = {
+  delete: "viewModels.facebook.jobs.actionDelete",
+  untag: "viewModels.facebook.jobs.actionUntag",
+  hide: "viewModels.facebook.jobs.actionHide",
+};
+
+const actionPresentKeys: Record<PostAction, string> = {
+  delete: "viewModels.facebook.jobs.actionDeletePresent",
+  untag: "viewModels.facebook.jobs.actionUntagPresent",
+  hide: "viewModels.facebook.jobs.actionHidePresent",
+};
+
 async function getCheckboxState(
   vm: FacebookViewModel,
   listIndex: number,
@@ -646,9 +658,12 @@ export async function runJobDeleteWallPosts(
     // infinite loop to loop through different actions
     for (const action of batchActions) {
       batchAction = action;
-      vm.instructions = vm.t("viewModels.facebook.jobs.checkBatchActionWallPosts", {
-        action: batchAction,
-      });
+      vm.instructions = vm.t(
+        "viewModels.facebook.jobs.checkBatchActionWallPosts",
+        {
+          action: vm.t(actionVerbKeys[batchAction]),
+        },
+      );
       // Loop through items, checking if any item match the current batchAction priority action.
       // Stop when adding a new item would reduce the priority (e.g. from delete -> hide).
       for (const { listIndex, itemIndex } of allItems) {
@@ -761,10 +776,13 @@ export async function runJobDeleteWallPosts(
 
       if (checkedCount !== 0) {
         // If actionable items found, no need to loop through other actions
-        vm.instructions = vm.t("viewModels.facebook.jobs.removeActionWallPosts", {
-          action: batchAction,
-          count: checkedCount,
-        });
+        vm.instructions = vm.t(
+          "viewModels.facebook.jobs.removeActionWallPosts",
+          {
+            action: vm.t(actionPresentKeys[batchAction]),
+            count: checkedCount,
+          },
+        );
         break;
       }
 

--- a/src/renderer/src/view_models/FacebookViewModel/types.ts
+++ b/src/renderer/src/view_models/FacebookViewModel/types.ts
@@ -35,6 +35,8 @@ export type FacebookJob = {
 export type FacebookProgress = {
   currentJob: string;
   wallPostsDeleted: number;
+  wallPostsUntagged: number;
+  wallPostsHidden: number;
   isDeleteWallPostsFinished: boolean;
 };
 
@@ -42,6 +44,8 @@ export function emptyFacebookProgress(): FacebookProgress {
   return {
     currentJob: "",
     wallPostsDeleted: 0,
+    wallPostsUntagged: 0,
+    wallPostsHidden: 0,
     isDeleteWallPostsFinished: false,
   };
 }

--- a/src/renderer/src/view_models/FacebookViewModel/view_model.test.ts
+++ b/src/renderer/src/view_models/FacebookViewModel/view_model.test.ts
@@ -463,6 +463,8 @@ describe("FacebookViewModel", () => {
 
       expect(progress.currentJob).toBe("");
       expect(progress.wallPostsDeleted).toBe(0);
+      expect(progress.wallPostsUntagged).toBe(0);
+      expect(progress.wallPostsHidden).toBe(0);
       expect(progress.isDeleteWallPostsFinished).toBe(false);
     });
 

--- a/src/renderer/src/views/facebook/components/FacebookProgressComponent.test.ts
+++ b/src/renderer/src/views/facebook/components/FacebookProgressComponent.test.ts
@@ -21,6 +21,8 @@ function createMockProgress(
   return {
     currentJob: "",
     wallPostsDeleted: 0,
+    wallPostsUntagged: 0,
+    wallPostsHidden: 0,
     isDeleteWallPostsFinished: false,
     ...overrides,
   };

--- a/src/renderer/src/views/facebook/components/FacebookProgressComponent.vue
+++ b/src/renderer/src/views/facebook/components/FacebookProgressComponent.vue
@@ -17,7 +17,7 @@ const wallPostsProgressHtml = computed(() => {
       deleteCount: props.progress.wallPostsDeleted.toLocaleString(),
       untagCount: props.progress.wallPostsUntagged.toLocaleString(),
       hideCount: props.progress.wallPostsHidden.toLocaleString(),
-    })
+    }),
   );
 });
 </script>

--- a/src/renderer/src/views/facebook/components/FacebookProgressComponent.vue
+++ b/src/renderer/src/views/facebook/components/FacebookProgressComponent.vue
@@ -14,15 +14,29 @@ defineProps<{
     <div class="progress-wrapper">
       <!-- Delete wall posts -->
       <template v-if="progress.currentJob == 'deleteWallPosts'">
-        <p>
+        <p v-if="progress.wallPostsDeleted > 0">
           {{
             t("viewModels.facebook.progress.wallPostsDeleted", {
               count: progress.wallPostsDeleted.toLocaleString(),
             })
           }}
-          <template v-if="progress.isDeleteWallPostsFinished">
-            {{ t("progress.savingComplete") }}
-          </template>
+        </p>
+        <p v-if="progress.wallPostsUntagged > 0">
+          {{
+            t("viewModels.facebook.progress.wallPostsUntagged", {
+              count: progress.wallPostsUntagged.toLocaleString(),
+            })
+          }}
+        </p>
+        <p v-if="progress.wallPostsHidden > 0">
+          {{
+            t("viewModels.facebook.progress.wallPostsHidden", {
+              count: progress.wallPostsHidden.toLocaleString(),
+            })
+          }}
+        </p>
+        <p v-if="progress.isDeleteWallPostsFinished">
+          {{ t("progress.savingComplete") }}
         </p>
       </template>
     </div>

--- a/src/renderer/src/views/facebook/components/FacebookProgressComponent.vue
+++ b/src/renderer/src/views/facebook/components/FacebookProgressComponent.vue
@@ -1,12 +1,25 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
+import { marked } from "marked";
 import type { FacebookProgress } from "../../../view_models/FacebookViewModel/types";
 
 const { t } = useI18n();
 
-defineProps<{
+const props = defineProps<{
   progress: FacebookProgress | null;
 }>();
+
+const wallPostsProgressHtml = computed(() => {
+  if (!props.progress) return "";
+  return marked.parse(
+    t("viewModels.facebook.progress.wallPostsProgress", {
+      deleteCount: props.progress.wallPostsDeleted.toLocaleString(),
+      untagCount: props.progress.wallPostsUntagged.toLocaleString(),
+      hideCount: props.progress.wallPostsHidden.toLocaleString(),
+    })
+  );
+});
 </script>
 
 <template>
@@ -14,27 +27,8 @@ defineProps<{
     <div class="progress-wrapper">
       <!-- Delete wall posts -->
       <template v-if="progress.currentJob == 'deleteWallPosts'">
-        <p v-if="progress.wallPostsDeleted > 0">
-          {{
-            t("viewModels.facebook.progress.wallPostsDeleted", {
-              count: progress.wallPostsDeleted.toLocaleString(),
-            })
-          }}
-        </p>
-        <p v-if="progress.wallPostsUntagged > 0">
-          {{
-            t("viewModels.facebook.progress.wallPostsUntagged", {
-              count: progress.wallPostsUntagged.toLocaleString(),
-            })
-          }}
-        </p>
-        <p v-if="progress.wallPostsHidden > 0">
-          {{
-            t("viewModels.facebook.progress.wallPostsHidden", {
-              count: progress.wallPostsHidden.toLocaleString(),
-            })
-          }}
-        </p>
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <div v-html="wallPostsProgressHtml" />
         <p v-if="progress.isDeleteWallPostsFinished">
           {{ t("progress.savingComplete") }}
         </p>

--- a/src/renderer/src/views/facebook/wizard/FacebookFinishedPage.test.ts
+++ b/src/renderer/src/views/facebook/wizard/FacebookFinishedPage.test.ts
@@ -105,7 +105,41 @@ describe("FacebookFinishedPage", () => {
       });
 
       expect(wrapper.text()).toContain("42");
-      expect(wrapper.text()).toContain("wall posts");
+      expect(wrapper.text()).toContain("wall posts deleted");
+    });
+
+    it("shows wall posts untagged count", () => {
+      const vm = createMockFacebookViewModel();
+      vm.progress.wallPostsUntagged = 15;
+
+      const wrapper = mount(FacebookFinishedPage, {
+        global: {
+          plugins: [i18n],
+        },
+        props: {
+          model: vm,
+        },
+      });
+
+      expect(wrapper.text()).toContain("15");
+      expect(wrapper.text()).toContain("wall posts untagged");
+    });
+
+    it("shows wall posts hidden count", () => {
+      const vm = createMockFacebookViewModel();
+      vm.progress.wallPostsHidden = 8;
+
+      const wrapper = mount(FacebookFinishedPage, {
+        global: {
+          plugins: [i18n],
+        },
+        props: {
+          model: vm,
+        },
+      });
+
+      expect(wrapper.text()).toContain("8");
+      expect(wrapper.text()).toContain("wall posts hidden");
     });
 
     it("formats large numbers with locale string", () => {

--- a/src/renderer/src/views/facebook/wizard/FacebookFinishedPage.vue
+++ b/src/renderer/src/views/facebook/wizard/FacebookFinishedPage.vue
@@ -27,11 +27,13 @@ const backToDashboard = () => {
 </script>
 
 <template>
-  <BaseWizardPage :breadcrumb-props="{
-    buttons: [],
-    label: t('facebook.finished.title'),
-    icon: getBreadcrumbIcon('delete'),
-  }" :button-props="{
+  <BaseWizardPage
+    :breadcrumb-props="{
+      buttons: [],
+      label: t('facebook.finished.title'),
+      icon: getBreadcrumbIcon('delete'),
+    }"
+    :button-props="{
       backButtons: [],
       nextButtons: [
         {
@@ -39,7 +41,8 @@ const backToDashboard = () => {
           action: backToDashboard,
         },
       ],
-    }">
+    }"
+  >
     <template #content>
       <div class="wizard-scroll-content">
         <div class="container mt-3">
@@ -50,21 +53,21 @@ const backToDashboard = () => {
                 <i class="fa-solid fa-fire delete-bullet" />
                 <strong>{{
                   model.progress.wallPostsDeleted.toLocaleString()
-                  }}</strong>
+                }}</strong>
                 {{ t("facebook.finished.wallPostsDeleted") }}
               </li>
               <li>
                 <i class="fa-solid fa-fire delete-bullet" />
                 <strong>{{
                   model.progress.wallPostsUntagged.toLocaleString()
-                  }}</strong>
+                }}</strong>
                 {{ t("facebook.finished.wallPostsUntagged") }}
               </li>
               <li>
                 <i class="fa-solid fa-fire delete-bullet" />
                 <strong>{{
                   model.progress.wallPostsHidden.toLocaleString()
-                  }}</strong>
+                }}</strong>
                 {{ t("facebook.finished.wallPostsHidden") }}
               </li>
             </ul>

--- a/src/renderer/src/views/facebook/wizard/FacebookFinishedPage.vue
+++ b/src/renderer/src/views/facebook/wizard/FacebookFinishedPage.vue
@@ -49,12 +49,26 @@ const backToDashboard = () => {
           <div class="finished">
             <h2>{{ t("finished.youJustDeleted") }}</h2>
             <ul>
-              <li>
+              <li v-if="model.progress.wallPostsDeleted > 0">
                 <i class="fa-solid fa-fire delete-bullet" />
                 <strong>{{
                   model.progress.wallPostsDeleted.toLocaleString()
                 }}</strong>
-                {{ t("facebook.finished.wallPosts") }}
+                {{ t("facebook.finished.wallPostsDeleted") }}
+              </li>
+              <li v-if="model.progress.wallPostsUntagged > 0">
+                <i class="fa-solid fa-fire delete-bullet" />
+                <strong>{{
+                  model.progress.wallPostsUntagged.toLocaleString()
+                }}</strong>
+                {{ t("facebook.finished.wallPostsUntagged") }}
+              </li>
+              <li v-if="model.progress.wallPostsHidden > 0">
+                <i class="fa-solid fa-fire delete-bullet" />
+                <strong>{{
+                  model.progress.wallPostsHidden.toLocaleString()
+                }}</strong>
+                {{ t("facebook.finished.wallPostsHidden") }}
               </li>
             </ul>
           </div>

--- a/src/renderer/src/views/facebook/wizard/FacebookFinishedPage.vue
+++ b/src/renderer/src/views/facebook/wizard/FacebookFinishedPage.vue
@@ -27,13 +27,11 @@ const backToDashboard = () => {
 </script>
 
 <template>
-  <BaseWizardPage
-    :breadcrumb-props="{
-      buttons: [],
-      label: t('facebook.finished.title'),
-      icon: getBreadcrumbIcon('delete'),
-    }"
-    :button-props="{
+  <BaseWizardPage :breadcrumb-props="{
+    buttons: [],
+    label: t('facebook.finished.title'),
+    icon: getBreadcrumbIcon('delete'),
+  }" :button-props="{
       backButtons: [],
       nextButtons: [
         {
@@ -41,33 +39,32 @@ const backToDashboard = () => {
           action: backToDashboard,
         },
       ],
-    }"
-  >
+    }">
     <template #content>
       <div class="wizard-scroll-content">
         <div class="container mt-3">
           <div class="finished">
             <h2>{{ t("finished.youJustDeleted") }}</h2>
             <ul>
-              <li v-if="model.progress.wallPostsDeleted > 0">
+              <li>
                 <i class="fa-solid fa-fire delete-bullet" />
                 <strong>{{
                   model.progress.wallPostsDeleted.toLocaleString()
-                }}</strong>
+                  }}</strong>
                 {{ t("facebook.finished.wallPostsDeleted") }}
               </li>
-              <li v-if="model.progress.wallPostsUntagged > 0">
+              <li>
                 <i class="fa-solid fa-fire delete-bullet" />
                 <strong>{{
                   model.progress.wallPostsUntagged.toLocaleString()
-                }}</strong>
+                  }}</strong>
                 {{ t("facebook.finished.wallPostsUntagged") }}
               </li>
-              <li v-if="model.progress.wallPostsHidden > 0">
+              <li>
                 <i class="fa-solid fa-fire delete-bullet" />
                 <strong>{{
                   model.progress.wallPostsHidden.toLocaleString()
-                }}</strong>
+                  }}</strong>
                 {{ t("facebook.finished.wallPostsHidden") }}
               </li>
             </ul>

--- a/src/shared_types/account.ts
+++ b/src/shared_types/account.ts
@@ -102,11 +102,15 @@ export type FacebookAccount = {
 export type FacebookProgressInfo = {
   accountUUID: string;
   totalWallPostsDeleted: number;
+  totalWallPostsUntagged: number;
+  totalWallPostsHidden: number;
 };
 
 export function emptyFacebookProgressInfo(): FacebookProgressInfo {
   return {
     accountUUID: "",
     totalWallPostsDeleted: 0,
+    totalWallPostsUntagged: 0,
+    totalWallPostsHidden: 0,
   };
 }

--- a/src/shared_types/facebook.ts
+++ b/src/shared_types/facebook.ts
@@ -10,11 +10,15 @@ export type FacebookJob = PlatformJob & {
 
 export type FacebookProgress = {
   wallPostsDeleted: number;
+  wallPostsUntagged: number;
+  wallPostsHidden: number;
 };
 
 export function emptyFacebookProgress(): FacebookProgress {
   return {
     wallPostsDeleted: 0,
+    wallPostsUntagged: 0,
+    wallPostsHidden: 0,
   };
 }
 


### PR DESCRIPTION
Fixes #649 

This PR does things slightly differently from the approach listed in the issue.

- It loops over the batch actions in priority (delete > untag > hide)
- It tries to select every item in the current priority batch action (delete in beginning and then so on) instead of determining the priority batch action from the first item
- If there is 0 items that the current priority action can be applied to, then it moves to the next action in the priority list, else it breaks from the loop and performs the action

This does make things slightly slower than before, but I think classifying (as suggested in the issue) would make it equally slow. I have added some test to replicate the issue and also tried to replicate the issue in a test account and in both cases, it seems to work. We may have to brainstorm later if we can improve performance, but this definitely seems to be working in deleting, untagging and hiding everything.

I think this process is also easier, if we want to provide a better summary of how many elements were deleted, how many were untagged and how many were hidden.