### PR TITLE
Allow for more URL changes during login

### DIFF
--- a/src/renderer/src/view_models/XViewModel/auth.ts
+++ b/src/renderer/src/view_models/XViewModel/auth.ts
@@ -14,7 +14,7 @@ export async function login(vm: XViewModel): Promise<void> {
   // Load the login page and wait for it to redirect to home
   await vm.loadURLWithRateLimit("https://x.com/login", [
     "https://x.com/home",
-    "https://x.com/i/flow/login",
+    "https://x.com/i/",
   ]);
   if (vm.cancelWaitForURL) {
     // If the user clicks archive only before the page is done loading, we cancel the login


### PR DESCRIPTION
I got a report from a Cyd user that 1) they were trying to login to their X account and it wasn't detecting it and 2) the UI for archive-only mode was confusing.

This PR addresses the first one. I'm not reproducing the issue, but I think this fixes it anyway, based on the error report they submitted. The login function includes:

```
  // Load the login page and wait for it to redirect to home
  await vm.loadURLWithRateLimit("https://x.com/login", [
    "https://x.com/home",
    "https://x.com/i/flow/login",
  ]);
```

It loads `https://x.com/login`, and the other two URLs (`https://x.com/home` and `https://x.com/i/flow/login`) are expected to load. Once it finally makes it to `https://x.com/home`, it concludes that the login was successful.

Based on the error report, it actually tried loading `https://x.com/i/jf/onboarding/web?mode=login`, which triggered an error. It seems that X changed their login flow, at least for this user. So to keep things simpler and more robust, I've changed it so that any URL that starts with `https://x.com/i/` is an expected URL and won't throw an error. This should allow URLs like `https://x.com/i/jf/onboarding/web?mode=login` through, and allow for completing the login.

This is from the error report that they submitted:

```json
{
  "logs": [
    {
      "timestamp": "2026-06-04T21:08:34.551Z",
      "func": "run",
      "message": "running state: Login"
    },
    {
      "timestamp": "2026-06-04T21:08:34.551Z",
      "func": "login",
      "message": "logging in"
    },
    {
      "timestamp": "2026-06-04T21:08:34.551Z",
      "func": "loadURLWithRateLimit",
      "message": [
        "https://x.com/login",
        [
          "https://x.com/home",
          "https://x.com/i/flow/login"
        ],
        false
      ]
    },
    {
      "timestamp": "2026-06-04T21:08:34.552Z",
      "func": "waitForLoadingToFinish",
      "message": "waiting for loading to finish"
    },
    {
      "timestamp": "2026-06-04T21:08:34.605Z",
      "func": "domReadyHandler",
      "message": "dom-ready"
    },
    {
      "timestamp": "2026-06-04T21:08:34.753Z",
      "func": "waitForLoadingToFinish",
      "message": "loading finished"
    },
    {
      "timestamp": "2026-06-04T21:08:34.753Z",
      "func": "loadURL",
      "message": "try #0, https://x.com/login"
    },
    {
      "timestamp": "2026-06-04T21:08:35.959Z",
      "func": "loadURL",
      "message": "URL loaded successfully"
    },
    {
      "timestamp": "2026-06-04T21:08:35.959Z",
      "func": "waitForLoadingToFinish",
      "message": "waiting for loading to finish"
    },
    {
      "timestamp": "2026-06-04T21:08:36.160Z",
      "func": "waitForLoadingToFinish",
      "message": "loading finished"
    },
    {
      "timestamp": "2026-06-04T21:08:36.160Z",
      "func": "loadURLWithRateLimit",
      "message": "URL loaded successfully"
    },
    {
      "timestamp": "2026-06-04T21:08:36.160Z",
      "func": "loadURLWithRateLimit",
      "message": "checking if URL changed"
    },
    {
      "timestamp": "2026-06-04T21:08:36.161Z",
      "func": "loadURLWithRateLimit",
      "message": "UNEXPECTED, URL change to https://x.com/i/jf/onboarding/web?mode=login"
    }
  ],
  "currentURL": "https://x.com/i/jf/onboarding/web?mode=login"
}
```