### PR TITLE
Attempt to fix XChat (Twitter DMs)

### DIFF
--- a/src/renderer/src/view_models/XViewModel/jobs_index.ts
+++ b/src/renderer/src/view_models/XViewModel/jobs_index.ts
@@ -215,11 +215,26 @@ export async function runJobIndexConversations(
     await vm.scrollUp(2000);
     await vm.sleep(1000);
 
-    // If the conversations list is empty, there is no search text field
+    // Check if loading the DM page is causing one to ask for PIN
+    if (await vm.detectTweetsDMPinPage("https://x.com/i/chat")) {
+      vm.log(
+        "runJobIndexConversations",
+        "asking for DM PIN detected",
+      );
+      vm.pause()
+      vm.showBrowser = true;
+      vm.showAutomationNotice = false;
+
+      await vm.waitForURL("https://x.com/home");
+
+      vm.showBrowser = false;
+      vm.showAutomationNotice = true;
+    }
+
+    // If the conversations list is empty, there is no search bar
     try {
-      // Wait for the search text field to appear with a 30 second timeout
       await vm.waitForSelector(
-        'section input[type="text"]',
+        '[data-testid="dm-inbox-panel"] [data-testid="dm-search-bar"]',
         "https://x.com/i/chat",
         30000,
       );
@@ -233,10 +248,10 @@ export async function runJobIndexConversations(
       break;
     }
 
-    // Wait for conversations to appear
+    // Wait for at least some conversations to appear
     try {
       await vm.waitForSelector(
-        'section div div[role="tablist"] div[data-testid="cellInnerDiv"]',
+        '[data-testid="dm-inbox-panel"] ul li a[id^="dm-conversation-option"]',
         "https://x.com/i/chat",
       );
       break;

--- a/src/renderer/src/view_models/XViewModel/view_model.ts
+++ b/src/renderer/src/view_models/XViewModel/view_model.ts
@@ -232,6 +232,12 @@ export class XViewModel extends BaseViewModel {
     return Helpers.syncProgress(this);
   }
 
+  async detectTweetsDMPinPage(url: string): Promise<boolean> {
+    const newURL = new URL(this.webview?.getURL() || "");
+    const originalURL = new URL(url);
+    return newURL !== originalURL && newURL.pathname == "/i/chat/pin/recovery"
+  }
+
   async indexTweetsHandleRateLimit(): Promise<boolean> {
     return IndexJobs.indexTweetsHandleRateLimit(this);
   }


### PR DESCRIPTION
Seems like ever since twitter moved to XChat (or if they moved user to XChat), seems like our DM parsing is broken. I have updated the selectors in this PR, but seems like our MITM logics for particular JSON are not functional anymore, since those API are not called anymore. I have looked into it for some time and I haven't been able to figure out a replacement GraphQL query that we can MITM. So we might need to actually parse the page DOM to get the conversations URL if we want to do that